### PR TITLE
update fastplotlib pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jupyterlab",
     "pytorch-lightning>=2.5.2",
     "tensorboard>=2.20.0",
-    "fastplotlib[imgui,notebook]>=0.5.1",
+    "fastplotlib[imgui,notebook]==0.6.1",
     "simplejpeg",
 ]
 


### PR DESCRIPTION
I think we should pin specific release of fastplotlib since the viz is so tied to the last features in fpl. This updates the pin to v0.6.1, no changes in features but fixes CI related issues due to upstream changes. See for more info: https://github.com/fastplotlib/fastplotlib/releases/tag/v0.6.1
