### PR TITLE
account for device obj

### DIFF
--- a/masknmf/utils/_cuda.py
+++ b/masknmf/utils/_cuda.py
@@ -1,7 +1,10 @@
 import torch
 from warnings import warn
 
-def torch_select_device(device: str = "auto", log_warning: bool = True) -> str:
+def torch_select_device(device: str | torch.device = "auto", log_warning: bool = True) -> str:
+    if isinstance(device, torch.device):
+        return device
+        
     if device.startswith("cpu"):  # seems like "cpu:<index>" is also a valid device, maybe for multi-CPU setups
         if log_warning:
             warn(


### PR DESCRIPTION
#165 introduced a bug. Once a device has been created and passed forward in downstream calls, we can just return that device:

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[3], line 2
      1 strategy = masknmf.PiecewiseRigidMotionCorrector()
----> 2 strategy.compute_template(movie)
      3 reg_array = masknmf.RegistrationArray(movie, strategy)

File [~/repos/masknmf-toolbox/masknmf/motion_correction/strategies.py:436](http://localhost:8888/lab/tree/repos/masknmf-toolbox/notebooks/repos/masknmf-toolbox/masknmf/motion_correction/strategies.py#line=435), in PiecewiseRigidMotionCorrector.compute_template(self, frames, num_splits_per_iteration, num_frames_per_split, num_iterations)
    429 def compute_template(
    430         self,
    431         frames: masknmf.ArrayLike | masknmf.LazyFrameLoader,
   (...)
    434         num_iterations: int = 1,
    435 ):
--> 436     rigid_strategy = RigidMotionCorrector(
    437         self.max_rigid_shifts,
    438         template=self.template.cpu().numpy() if self.template is not None else None,
    439         pixel_weighting=self.pixel_weighting,
    440         batch_size=self.batch_size,
    441         device=self.device,
    442     )
    444     rigid_strategy.compute_template(
    445         frames,
    446     )
    448     self._template = rigid_strategy.template

File [~/repos/masknmf-toolbox/masknmf/motion_correction/strategies.py:254](http://localhost:8888/lab/tree/repos/masknmf-toolbox/notebooks/repos/masknmf-toolbox/masknmf/motion_correction/strategies.py#line=253), in RigidMotionCorrector.__init__(self, max_shifts, template, pixel_weighting, batch_size, device)
    246 def __init__(
    247         self,
    248         max_shifts: tuple[int, int] = (15, 15),
   (...)
    252         device: str = "auto",
    253 ):
--> 254     super().__init__(template, batch_size=batch_size, device=device)
    256     self._max_shifts = max_shifts
    257     self._pixel_weighting = pixel_weighting

File [~/repos/masknmf-toolbox/masknmf/motion_correction/strategies.py:26](http://localhost:8888/lab/tree/repos/masknmf-toolbox/notebooks/repos/masknmf-toolbox/masknmf/motion_correction/strategies.py#line=25), in MotionCorrectionStrategy.__init__(self, template, batch_size, device)
     20 def __init__(
     21         self,
     22         template: Optional[np.ndarray] = None,
     23         batch_size: int = 200,
     24         device: str = "auto",
     25 ):
---> 26     self._device = torch_select_device(device)
     27     self._template = template
     28     self._batch_size = batch_size

File [~/repos/masknmf-toolbox/masknmf/utils/_cuda.py:5](http://localhost:8888/lab/tree/repos/masknmf-toolbox/notebooks/repos/masknmf-toolbox/masknmf/utils/_cuda.py#line=4), in torch_select_device(device, log_warning)
      4 def torch_select_device(device: str = "auto", log_warning: bool = True) -> str:
----> 5     if device.startswith("cpu"):  # seems like "cpu:<index>" is also a valid device, maybe for multi-CPU setups
      6         if log_warning:
      7             warn(
      8                 "You've explicitly selected to perform computations on the cpu, "
      9                 "performance will be significantly slower"
     10             )

AttributeError: 'torch.device' object has no attribute 'startswith'
```