### PR TITLE
Fix minor noise projection in blockwise singlepass via final fixed-V LS refit

### DIFF
--- a/masknmf/compression/decomposition.py
+++ b/masknmf/compression/decomposition.py
@@ -920,9 +920,6 @@ def blockwise_decomposition_singlepass(
         left = left[:, indices_to_keep]
         right = right[indices_to_keep, :]
         sing = sing[indices_to_keep]
-    local_spatial_basis = (spatial_basis_orthogonal @ left).reshape(
-        (fov_dim1, fov_dim2, -1)
-    )
     local_temporal_basis = sing[:, None] * right
 
     if temporal_denoiser is not None:
@@ -932,6 +929,12 @@ def blockwise_decomposition_singlepass(
         else:
             local_temporal_basis -= torch.mean(local_temporal_basis, dim=1, keepdims=True)
 
+    v = local_temporal_basis  # (r, T), final temporal basis
+    Q, R = torch.linalg.qr(v.T, mode="reduced")                 # Q:(T,r), R:(r,r)
+    # U = argmin_U ||X - U V||_F^2, via QR solve
+    local_spatial_basis_r = torch.linalg.solve(R, (Q.T @ subset_r.T)).T  # (P, r)
+    local_spatial_basis = local_spatial_basis_r.reshape(fov_dim1, fov_dim2, -1)
+   
     return local_spatial_basis, local_temporal_basis, subset_mean, subset_noise_std
 
 def residual_std_calculation(spatial_decomposition: torch.tensor,
@@ -1401,4 +1404,3 @@ def pmd_decomposition(
     )
     display("PMD Objected constructed")
     return final_pmd_arr
-


### PR DESCRIPTION
## Summary

This PR fixes a consistency issue in `blockwise_decomposition_singlepass`.

After the final temporal basis `V` is computed (and optionally denoised), we now recompute the spatial basis `U` using a least-squares fit on the original normalized block.

This removes the extra spatial-projection path and ensures that the returned `U` is the optimal fit for the final `V`.


## What Changed

1. Keep the existing pipeline for estimating the final temporal basis `V`.
2. Before returning, recompute `U` by solving:

   ```
   U = argmin ||X - U V||_F^2
   ```

   using a QR-based solve.
3. No change to behavior for empty or rank-0 edge cases.

Note: No algorithmic change to temporal basis estimation itself. By refitting `U` with `V` fixed,`U` is now consistent with the actual basis used for reconstruction. Minor projection artifacts are removed.
