### PR TITLE
Pmd blockwise rank storage (#178)

### DIFF
--- a/masknmf/compression/decomposition.py
+++ b/masknmf/compression/decomposition.py
@@ -1247,6 +1247,7 @@ def pmd_decomposition(
     spatial_overall_unweighted_values = []
     cumulative_weights = torch.zeros((fov_dim1, fov_dim2), dtype=dtype, device=device)
     total_temporal_fit = []
+    blockwise_ranks = []
 
     display("Finding spatiotemporal roughness thresholds")
     spatial_roughness_threshold, temporal_roughness_threshold = threshold_heuristic(
@@ -1294,6 +1295,9 @@ def pmd_decomposition(
 
             dataset_mean[slice_dim1, slice_dim2] = subset_mean
             dataset_noise_std[slice_dim1, slice_dim2] = subset_noise_std
+
+            # Append the rank to storage even if rank = 0
+            blockwise_ranks.append(local_temporal_basis.shape[0])
 
             if local_temporal_basis.shape[0] == 0:
                 continue
@@ -1371,6 +1375,8 @@ def pmd_decomposition(
     else:
         v_aggregated = torch.concatenate(total_temporal_fit, dim=0)
 
+    blockwise_ranks = torch.tensor(blockwise_ranks)
+
     interpolation_weightings = torch.reciprocal(
         cumulative_weights.flatten()[final_row_indices]
     )
@@ -1396,6 +1402,9 @@ def pmd_decomposition(
         dataset_noise_std,
         u_local_projector=u_local_projector.cpu()
         if u_local_projector is not None
+        else None,
+        block_ranks = blockwise_ranks.cpu() 
+        if blockwise_ranks is not None
         else None,
         device="cpu",
     )

--- a/masknmf/compression/pmd_array.py
+++ b/masknmf/compression/pmd_array.py
@@ -107,6 +107,7 @@ class PMDArray(FactorizedVideo, Serializer):
         "u_local_projector",
         "mean_img",
         "var_img"
+        "block_ranks"
     }
 
     def __init__(
@@ -117,6 +118,7 @@ class PMDArray(FactorizedVideo, Serializer):
         mean_img: torch.tensor,
         var_img: torch.tensor,
         u_local_projector: Optional[torch.sparse_coo_tensor] = None,
+        block_ranks: Optional[torch.tensor] = None,
         device: str = "cpu",
         rescale: bool = True,
     ):
@@ -132,6 +134,7 @@ class PMDArray(FactorizedVideo, Serializer):
             mean_img (torch.tensor): shape (fov_dim1, fov_dim2). The pixelwise mean of the data
             var_img (torch.tensor): shape (fov_dim1, fov_dim2). A pixelwise noise normalizer for the data
             u_local_projector (Optional[torch.sparse_coo_tensor]): shape (pixels, rank)
+            block_ranks (Optional[torch.tensor]): shape (n blocks). Stores final rank of each block
             resid_std (torch.tensor): The residual standard deviation, shape (fov_dim1, fov_dim2)
             device (str): The device on which computations occur/data is stored
             rescale (bool): True if we rescale the PMD data (i.e. multiply by the pixelwise normalizer
@@ -144,6 +147,10 @@ class PMDArray(FactorizedVideo, Serializer):
             self._u_local_projector = u_local_projector.to(device).coalesce()
         else:
             self._u_local_projector = None
+        if block_ranks is not None:
+            self._block_ranks = block_ranks.to(device)
+        else:
+            self._block_ranks = None
 
         self._device = self._u.device
         self._shape = tuple(shape)
@@ -185,6 +192,8 @@ class PMDArray(FactorizedVideo, Serializer):
         self._device = self._u.device
         if self.u_local_projector is not None:
             self._u_local_projector = self.u_local_projector.to(device)
+        if self.block_ranks is not None:
+            self._block_ranks = self._block_ranks.to(device)
 
     @property
     def u(self) -> torch.sparse_coo_tensor:
@@ -193,6 +202,10 @@ class PMDArray(FactorizedVideo, Serializer):
     @property
     def u_local_projector(self) -> Optional[torch.sparse_coo_tensor]:
         return self._u_local_projector
+
+    @property 
+    def block_ranks(self) -> Optional[torch.tensor]:
+        return self._block_ranks
 
     @property
     def pmd_rank(self) -> int:

--- a/masknmf/diagnostics/voltage_diagnostics.py
+++ b/masknmf/diagnostics/voltage_diagnostics.py
@@ -56,6 +56,7 @@ def onephoton_voltage_snr_stats(full_moco_dense: np.ndarray,
                                 temporal_trace: np.ndarray,
                                 trend_filter_cutoff_freq: float = 1,
                                 spike_detect_cutoff_freq: float = 3,
+                                spike_min_distance: int = 10,
                                 mad_cutoff=8,
                                 sampling_rate: float = 800,
                                 reverse_polarity: bool = True):
@@ -69,6 +70,7 @@ def onephoton_voltage_snr_stats(full_moco_dense: np.ndarray,
         temporal_trace (np.ndarray): Shape (num_frames,)
         trend_filter_cutoff_freq (float): the frequency cutoff for highpass filtering to remove optostim related smooth trends
         spike_detect_cutoff_freq (float): the highpass filter frequency used before running MAD thresholding to identify spikes
+        spike_min_distance (int): The minimum distance between identified spikes in frames.
         mad_cutoff (float): the mad threshold used to identify spiking locations (and eventually find the spike peak times).
         sampling_rate (float): The sampling rate of the data in Hz
         reverse_polarity (bool): True if the raw stack contains a negatively tuned indicator.
@@ -114,7 +116,8 @@ def onephoton_voltage_snr_stats(full_moco_dense: np.ndarray,
                                                                   sampling_rate).squeeze()
 
     thres_c = masknmf.diagnostics.voltage_diagnostics.mad_filter_for_spikes(hp_filter_c, mad_cutoff)
-    c_peaks, _ = masknmf.diagnostics.voltage_diagnostics.detect_peaks(thres_c, distance=10)
+    c_peaks, _ = masknmf.diagnostics.voltage_diagnostics.detect_peaks(thres_c,
+                                                                      spike_min_distance)
 
     # For each peak, estimate the splike amplitude. Strategy: subtract the 1Hz low-pass
     pmd_spike_heights = pmd_roi_avg[c_peaks] - pmd_roi_lowpass[c_peaks]


### PR DESCRIPTION
* Added optional property to store the per block rank count to PMDArray as PMDArray.block_ranks stored as a torch tensor. (Solves #178)

* Implemented counting and storing of block ranks to pmd_decomposition function.

* Added option to run bandpass filters on factorized movies (in V) or vectorized movie arrays similar to the high pass filter

* Added variable to control spike detection minimum distance window (was previously hard set to 10)