### PR TITLE
Includes managed arrays with caching so they are not re constructed e…

### DIFF
--- a/masknmf/arrays/__init__.py
+++ b/masknmf/arrays/__init__.py
@@ -1,4 +1,8 @@
-from .array_interfaces import LazyFrameLoader, FactorizedVideo, ArrayLike
+from .array_interfaces import LazyFrameLoader, ArrayLike, TensorFlyWeight
 from .data_loaders import TiffArray, Hdf5Array
 
-__all__ = ["TiffArray", "Hdf5Array", "LazyFrameLoader", "FactorizedVideo", "ArrayLike"]
+__all__ = ["TiffArray",
+           "Hdf5Array",
+           "LazyFrameLoader",
+           "ArrayLike",
+           "TensorFlyWeight"]

--- a/masknmf/arrays/array_interfaces.py
+++ b/masknmf/arrays/array_interfaces.py
@@ -3,7 +3,7 @@ from typing import *
 from abc import ABC, abstractmethod
 import numpy as np
 
-
+import torch
 def is_arraylike(obj):
     """Returns if the object is sufficiently array-like for lazy compute or loading"""
     for attr in ["dtype", "shape", "ndim", "__getitem__"]:
@@ -140,13 +140,40 @@ class ArrayLike(ABC):
         # Step 1: index the frames (dimension 0)
         pass
 
+class TensorFlyWeight:
+    """
+    Generic class for managing a collection of tensors across multiple objects
+    """
+    def __init__(self, **kwargs):
+        device = None
+        for name, value in kwargs.items():
+            if isinstance(value, torch.Tensor):
+                if device is None:
+                    device = value.device
+                setattr(self, name, value.to(device))
 
-class FactorizedVideo(ArrayLike):
-    """
-    This captures the numpy array-like functionality for factorized videos in our NMF model.
-    Different class just for separating instance checks?
-    """
-    pass
+            else:
+                raise ValueError(f"field {name} is not a torch Tensor object")
+
+    @property
+    def device(self) -> str | None:
+        device = None
+        for name in vars(self):
+            data = getattr(self, name)
+            if device is None:
+                device = data.device
+            if data.device != device:
+                raise ValueError("Not all attributes on same device")
+        return device
+
+    def list_tensor_attributes(self) -> list[str]:
+        return list(vars(self).keys())
+
+    def to(self, device: str):
+        for name in vars(self):
+            curr_tensor = getattr(self, name)
+            new_values = curr_tensor.to(device)
+            setattr(self, name, new_values)
 
 
 class LazyFrameLoader(ArrayLike):

--- a/masknmf/arrays/array_interfaces.py
+++ b/masknmf/arrays/array_interfaces.py
@@ -151,6 +151,9 @@ class TensorFlyWeight:
                 if device is None:
                     device = value.device
                 setattr(self, name, value.to(device))
+            ##Useful to track None types
+            if value is None:
+                setattr(self, name, None)
 
             else:
                 raise ValueError(f"field {name} is not a torch Tensor object")
@@ -160,14 +163,16 @@ class TensorFlyWeight:
         device = None
         for name in vars(self):
             data = getattr(self, name)
+            if data is None:
+                continue
             if device is None:
                 device = data.device
             if data.device != device:
                 raise ValueError("Not all attributes on same device")
         return device
 
-    def list_tensor_attributes(self) -> list[str]:
-        return list(vars(self).keys())
+    def list_tensor_attributes(self) -> dict[str, torch.Tensor | None]:
+        return vars(self)
 
     def validate_attributes(self, attr_list):
         for name in attr_list:
@@ -177,8 +182,9 @@ class TensorFlyWeight:
     def to(self, device: str):
         for name in vars(self):
             curr_tensor = getattr(self, name)
-            new_values = curr_tensor.to(device)
-            setattr(self, name, new_values)
+            if curr_tensor is not None:
+                new_values = curr_tensor.to(device)
+                setattr(self, name, new_values)
 
 
 class LazyFrameLoader(ArrayLike):

--- a/masknmf/arrays/array_interfaces.py
+++ b/masknmf/arrays/array_interfaces.py
@@ -169,6 +169,11 @@ class TensorFlyWeight:
     def list_tensor_attributes(self) -> list[str]:
         return list(vars(self).keys())
 
+    def validate_attributes(self, attr_list):
+        for name in attr_list:
+            if not hasattr(self, name):
+                raise ValueError(f"Required attribute: {name} missing from constructor")
+
     def to(self, device: str):
         for name in vars(self):
             curr_tensor = getattr(self, name)

--- a/masknmf/compression/decomposition.py
+++ b/masknmf/compression/decomposition.py
@@ -1380,12 +1380,12 @@ def pmd_decomposition(
     num_rows = fov_dim1 * fov_dim2
     u_local_projector = torch.sparse_coo_tensor(
         final_indices, spatial_overall_unweighted_values, (num_rows, num_cols)
-    )
+    ).coalesce()
 
     final_indices = torch.stack([final_row_indices, final_column_indices], dim=0)
     u_aggregated = torch.sparse_coo_tensor(
         final_indices, spatial_overall_values, (num_rows, num_cols)
-    )
+    ).coalesce()
     display(f"Constructed U matrix. Rank of U is {u_aggregated.shape[1]}")
 
     final_pmd_arr = PMDArray.from_tensors(

--- a/masknmf/compression/decomposition.py
+++ b/masknmf/compression/decomposition.py
@@ -1388,7 +1388,7 @@ def pmd_decomposition(
     )
     display(f"Constructed U matrix. Rank of U is {u_aggregated.shape[1]}")
 
-    final_pmd_arr = PMDArray(
+    final_pmd_arr = PMDArray.from_tensors(
         (num_frames, fov_dim1, fov_dim2),
         u_aggregated.cpu(),
         v_aggregated.cpu(),

--- a/masknmf/compression/pmd_array.py
+++ b/masknmf/compression/pmd_array.py
@@ -273,7 +273,7 @@ class PMDArray(ArrayLike, Serializer):
                              (self.shape[1],self.shape[2]))
 
     def project_frames(
-        self, frames: torch.tensor, standardize: Optional[bool] = True
+        self, frames: torch.Tensor, standardize: Optional[bool] = True
     ) -> torch.Tensor:
         """
         Projects frames onto the spatial basis, using the u_projector property. u_projector must be defined.

--- a/masknmf/compression/pmd_array.py
+++ b/masknmf/compression/pmd_array.py
@@ -211,9 +211,13 @@ class PMDArray(ArrayLike, Serializer):
     def var_img(self) -> torch.Tensor:
         return self.flyweight.var_img
 
-    def to(self, device: str):
-        self._flyweight.to(device)
-        self._pixel_mat = self._pixel_mat.to(device)
+    def to(self, new_device: str):
+        if self._flyweight.device != new_device:
+            self._flyweight.to(new_device)
+        self._move_local_tensors(new_device)
+
+    def _move_local_tensors(self, new_device: str):
+        self._pixel_mat = self._pixel_mat.to(new_device)
 
     @property
     def device(self) -> str:

--- a/masknmf/compression/pmd_array.py
+++ b/masknmf/compression/pmd_array.py
@@ -1,4 +1,5 @@
-from masknmf.arrays.array_interfaces import LazyFrameLoader, FactorizedVideo, ArrayLike
+from masknmf.arrays.array_interfaces import LazyFrameLoader, ArrayLike, TensorFlyWeight
+from masknmf.utils._serialization import load_dict
 from masknmf.utils import Serializer
 import torch
 from typing import *
@@ -96,7 +97,7 @@ def _construct_identity_torch_sparse_tensor(dimsize: int, device: str = "cpu"):
     sparse_tensor = torch.sparse_coo_tensor(indices, values, (dimsize, dimsize))
     return sparse_tensor
 
-class PMDArray(FactorizedVideo, Serializer):
+class PMDArray(ArrayLike, Serializer):
     """
     Factorized demixing array for PMD movie
     """
@@ -112,49 +113,87 @@ class PMDArray(FactorizedVideo, Serializer):
     def __init__(
         self,
         shape: Tuple[int, int, int] | np.ndarray,
-        u: torch.sparse_coo_tensor,
-        v: torch.tensor,
-        mean_img: torch.tensor,
-        var_img: torch.tensor,
-        u_local_projector: Optional[torch.sparse_coo_tensor] = None,
+        flyweight: TensorFlyWeight,
         device: str = "cpu",
         rescale: bool = True,
     ):
         """
-        Key assumption: the spatial basis matrix U has n + k columns; the first n columns is blocksparse (this serves
-        as a local spatial basis for the data) and the last k columns can have unconstrained spatial support (these serve
-        as a global spatial basis for the data).
-
-        Args:
-            shape (tuple): (num_frames, fov_dim1, fov_dim2)
-            u (torch.sparse_coo_tensor): shape (pixels, rank)
-            v (torch.tensor): shape (rank, frames)
-            mean_img (torch.tensor): shape (fov_dim1, fov_dim2). The pixelwise mean of the data
-            var_img (torch.tensor): shape (fov_dim1, fov_dim2). A pixelwise noise normalizer for the data
-            u_local_projector (Optional[torch.sparse_coo_tensor]): shape (pixels, rank)
-            resid_std (torch.tensor): The residual standard deviation, shape (fov_dim1, fov_dim2)
-            device (str): The device on which computations occur/data is stored
-            rescale (bool): True if we rescale the PMD data (i.e. multiply by the pixelwise normalizer
-                and add back the mean) in __getitem__
+        See from_tensors class method for documentation
         """
-        self._u = u.to(device).coalesce()
-        self._device = self._u.device
-        self._v = v.to(device)
-        if u_local_projector is not None:
-            self._u_local_projector = u_local_projector.to(device).coalesce()
-        else:
-            self._u_local_projector = None
-
-        self._device = self._u.device
         self._shape = tuple(shape)
-
-        self.pixel_mat = torch.arange(
-            self.shape[1] * self.shape[2], device=self.device
-        ).reshape(self.shape[1], self.shape[2])
-        self._order = "C"
-        self._mean_img = mean_img.to(self.device).float()
-        self._var_img = var_img.to(self.device).float()
         self._rescale = rescale
+
+        ##Set up the flyweight and all other tensors
+        self._flyweight = flyweight
+        self._flyweight.to(device)
+
+        self._pixel_mat = torch.arange(
+            self.shape[1] * self.shape[2], device=self.flyweight.device,
+        ).reshape(self.shape[1], self.shape[2])
+
+
+
+    @property
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
+    @classmethod
+    def from_tensors(cls,
+                   shape: Tuple[int, int, int] | np.ndarray,
+                   u: torch.sparse_coo_tensor,
+                   v: torch.tensor,
+                   mean_img: torch.tensor,
+                   var_img: torch.tensor,
+                   u_local_projector: Optional[torch.sparse_coo_tensor] = None,
+                   device: str = "cpu",
+                   rescale: bool = True):
+
+        """
+            Key assumption: the spatial basis matrix U has n + k columns; the first n columns is blocksparse (this serves
+            as a local spatial basis for the data) and the last k columns can have unconstrained spatial support (these serve
+            as a global spatial basis for the data).
+
+            Args:
+                shape (tuple): (num_frames, fov_dim1, fov_dim2)
+                u (torch.sparse_coo_tensor): shape (pixels, rank)
+                v (torch.tensor): shape (rank, frames)
+                mean_img (torch.tensor): shape (fov_dim1, fov_dim2). The pixelwise mean of the data
+                var_img (torch.tensor): shape (fov_dim1, fov_dim2). A pixelwise noise normalizer for the data
+                u_local_projector (Optional[torch.sparse_coo_tensor]): shape (pixels, rank)
+                resid_std (torch.tensor): The residual standard deviation, shape (fov_dim1, fov_dim2)
+                device (str): The device on which computations occur/data is stored
+                rescale (bool): True if we rescale the PMD data (i.e. multiply by the pixelwise normalizer
+                    and add back the mean) in __getitem__
+        """
+        flyweight = TensorFlyWeight(u=u.float(),
+                                    v=v.float(),
+                                    mean_img=mean_img.float(),
+                                    var_img=var_img.float(),
+                                    u_local_projector=u_local_projector.float() if u_local_projector is not None else None)
+        return cls(shape,
+                   flyweight,
+                   device=device,
+                   rescale = rescale)
+
+
+    @classmethod
+    def from_flyweight(cls,
+                       shape: Tuple[int, int, int] | np.ndarray,
+                       flyweight: TensorFlyWeight,
+                       device: str = "cpu",
+                       rescale: bool = True
+                       ):
+        """
+        Memory efficient way to construct PMD Array from a flyweight tensor manager. See from_array for parameter documentation
+        """
+        return cls(shape,
+                   flyweight,
+                   device=device,
+                   rescale=rescale)
+
+    @classmethod
+    def from_hdf5(cls, path, **kwargs):
+        d = load_dict(path, Serializer.__name__)
+        return cls.from_tensors(**d, **kwargs)
 
     @property
     def rescale(self) -> bool:
@@ -165,42 +204,38 @@ class PMDArray(FactorizedVideo, Serializer):
         self._rescale = new_state
 
     @property
-    def mean_img(self) -> torch.tensor:
-        return self._mean_img
+    def mean_img(self) -> torch.Tensor:
+        return self.flyweight.mean_img
 
     @property
-    def var_img(self) -> torch.tensor:
-        return self._var_img
-
-    @property
-    def device(self) -> torch.device:
-        return self._device
+    def var_img(self) -> torch.Tensor:
+        return self.flyweight.var_img
 
     def to(self, device: str):
-        self._u = self._u.to(device)
-        self._v = self._v.to(device)
-        self._mean_img = self._mean_img.to(device)
-        self._var_img = self._var_img.to(device)
-        self.pixel_mat = self.pixel_mat.to(device)
-        self._device = self._u.device
-        if self.u_local_projector is not None:
-            self._u_local_projector = self.u_local_projector.to(device)
+        self._flyweight.to(device)
+        self._pixel_mat = self._pixel_mat.to(device)
+
+    @property
+    def device(self) -> str:
+        return self.flyweight.device
 
     @property
     def u(self) -> torch.sparse_coo_tensor:
-        return self._u
+        return self.flyweight.u
 
     @property
     def u_local_projector(self) -> Optional[torch.sparse_coo_tensor]:
-        return self._u_local_projector
+        if hasattr(self.flyweight, "u_local_projector"):
+            return self.flyweight.u_local_projector
+        return None
 
     @property
     def pmd_rank(self) -> int:
         return self.u.shape[1]
 
     @property
-    def v(self) -> torch.tensor:
-        return self._v
+    def v(self) -> torch.Tensor:
+        return self.flyweight.v
 
     @property
     def dtype(self) -> str:
@@ -215,15 +250,6 @@ class PMDArray(FactorizedVideo, Serializer):
         Array shape (n_frames, dims_x, dims_y)
         """
         return self._shape
-
-    @property
-    def order(self) -> str:
-        """
-        The spatial data is "flattened" from 2D into 1D.
-        This is not user-modifiable; "F" ordering is undesirable in PyTorch
-        """
-        return self._order
-
     @property
     def ndim(self) -> int:
         """
@@ -231,11 +257,11 @@ class PMDArray(FactorizedVideo, Serializer):
         """
         return len(self.shape)
     
-    def calculate_rank_heatmap(self) -> torch.tensor:
+    def calculate_rank_heatmap(self) -> torch.Tensor:
         """
         Generates rank heatmap image based on U. Equal to row summation of binarized U matrix.
         Returns:
-            rank_heatmap (torch.tensor). Shape (fov_dim1, fov_dim2).
+            rank_heatmap (torch.Tensor). Shape (fov_dim1, fov_dim2).
         """
         binarized_u = torch.sparse_coo_tensor(
             self.u.indices(), 
@@ -248,15 +274,15 @@ class PMDArray(FactorizedVideo, Serializer):
 
     def project_frames(
         self, frames: torch.tensor, standardize: Optional[bool] = True
-    ) -> torch.tensor:
+    ) -> torch.Tensor:
         """
         Projects frames onto the spatial basis, using the u_projector property. u_projector must be defined.
         Args:
-            frames (torch.tensor). Shape (fov_dim1, fov_dim2, num_frames) or (fov_dim1*fov_dim2, num_frames).
+            frames (torch.Tensor). Shape (fov_dim1, fov_dim2, num_frames) or (fov_dim1*fov_dim2, num_frames).
                 Frames which we want to project onto the spatial basis.
             standardize (Optional[bool]): Indicates whether the frames of data are standardized before projection is performed
         Returns:
-            projected_frames (torch.tensor). Shape (fov_dim1 * fov_dim2, num_frames).
+            projected_frames (torch.Tensor). Shape (fov_dim1 * fov_dim2, num_frames).
         """
         if self.u_local_projector is None:
             raise ValueError(
@@ -284,12 +310,12 @@ class PMDArray(FactorizedVideo, Serializer):
     def getitem_tensor(
         self,
         item: Union[int, list, np.ndarray, Tuple[Union[int, np.ndarray, slice, range]]],
-    ) -> torch.tensor:
+    ) -> torch.Tensor:
         frame_indexer, item = self._parse_indices(item)
 
         # Step 3: Now slice the data with frame_indexer (careful: if the ndims has shrunk, add a dim)
-        v_crop = self._v[:, frame_indexer]
-        if v_crop.ndim < self._v.ndim:
+        v_crop = self.v[:, frame_indexer]
+        if v_crop.ndim < self.v.ndim:
             v_crop = v_crop.unsqueeze(1)
 
 
@@ -317,14 +343,14 @@ class PMDArray(FactorizedVideo, Serializer):
 
             spatial_crop_terms = (term_1, term_2)
 
-            pixel_space_crop = self.pixel_mat[spatial_crop_terms]
+            pixel_space_crop = self._pixel_mat[spatial_crop_terms]
             mean_img_crop = self.mean_img[spatial_crop_terms].flatten()
             var_img_crop = self.var_img[spatial_crop_terms].flatten()
             u_indices = pixel_space_crop.flatten()
-            u_crop = torch.index_select(self._u, 0, u_indices)
+            u_crop = torch.index_select(self.u, 0, u_indices)
             implied_fov = pixel_space_crop.shape
         else:
-            u_crop = self._u
+            u_crop = self.u
             mean_img_crop = self.mean_img.flatten()
             var_img_crop = self.var_img.flatten()
             implied_fov = self.shape[1], self.shape[2]

--- a/masknmf/demixing/demixing_arrays/__init__.py
+++ b/masknmf/demixing/demixing_arrays/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     "ResidualCorrelationImages",
     "ResidCorrMode",
     "FluctuatingBackgroundArray",
-    "StaticBaselineArray",
+    "StaticBackgroundArray",
     "ColorfulACArray",
     "ResidualArray"
 ]

--- a/masknmf/demixing/demixing_arrays/__init__.py
+++ b/masknmf/demixing/demixing_arrays/__init__.py
@@ -2,6 +2,7 @@ from masknmf.demixing.demixing_arrays.ac_array import ACArray
 from masknmf.demixing.demixing_arrays.standard_correlation_images import StandardCorrelationImages
 from masknmf.demixing.demixing_arrays.residual_correlation_images import ResidualCorrelationImages, ResidCorrMode
 from masknmf.demixing.demixing_arrays.fluctuating_background_array import FluctuatingBackgroundArray
+from masknmf.demixing.demixing_arrays.static_baseline import StaticBackgroundArray
 from masknmf.demixing.demixing_arrays.colorful_ac_array import ColorfulACArray
 from masknmf.demixing.demixing_arrays.residual_array import ResidualArray
 __all__ = [
@@ -10,6 +11,7 @@ __all__ = [
     "ResidualCorrelationImages",
     "ResidCorrMode",
     "FluctuatingBackgroundArray",
+    "StaticBaselineArray",
     "ColorfulACArray",
     "ResidualArray"
 ]

--- a/masknmf/demixing/demixing_arrays/ac_array.py
+++ b/masknmf/demixing/demixing_arrays/ac_array.py
@@ -14,43 +14,77 @@ class ACArray(FactorizedVideo):
         self,
         fov_shape: tuple[int, int],
         a: torch.sparse_coo_tensor,
-        c: torch.tensor,
+        c: torch.Tensor,
+        normalizer: Optional[torch.Tensor] = None,
+        rescale: bool = False
     ):
+        DATA_ARRAYS = ["a", "c"]
         """
         Args:
             fov_shape (tuple): (fov_dim1, fov_dim2)
             a (torch.sparse_coo_tensor): Shape (pixels, components)
-            c (torch.tensor). Shape (frames, components)
-            mask (torch.tensor). Shape (num_components). A mask of 1s and 0s indicating which neurons are actively displayed
-                (and which are effectively zerod out). Can be toggled
+            c (torch.Tensor). Shape (frames, components)
+            normalizer (Optional[torch.Tensor]): A (height, width)-shaped tensor. Multiply the array pixelwise by this
+                value to obtain results in the "raw data" space.
+            rescale (bool): Whether or not to rescale the data to the raw data space. This determines the output of getitem
         """
 
         self._a = a.coalesce()
         self._c = c
-        # Check that both objects are on same device
-        if self._a.device != self._c.device:
-            raise ValueError(f"Spatial and Temporal matrices are not on same device")
-        self._device = self._a.device
+
         num_frames = c.shape[0]
         self._shape = tuple(map(int, (num_frames, *fov_shape)))
-        self.pixel_mat = np.arange(np.prod(self.shape[-2:])).reshape([self.shape[-2], self.shape[-1]])
-        self.pixel_mat = torch.from_numpy(self.pixel_mat).long().to(self.device)
+        self.pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
         self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
         self._centers = None
         self._bbox = None
         self._contours = None
 
-    @property
-    def device(self) -> str:
-        return self._device
+        self._rescale = rescale
+        self._normalizer = normalizer
+        if self._normalizer is not None:
+            if self._normalizer.shape[0] != self.shape[1] or self._normalizer.shape[1] != self.shape[2]:
+                raise ValueError("Normalizer had dimensions not equal to the fov")
+
+
+    def _find_common_device(self):
+        """
+        Finds the common device that for all data tensors. Throws error if no such device exists
+        """
+        device=None
+        for i, name in enumerate(DATA_ARRAYS):
+            arr = getattr(self, name)
+            if i == 0:
+                device = arr.device
+            else:
+                if not arr.device == device:
+                    raise ValueError("Not all tensors in fluctuating background array are on same device")
+        return device
 
     @property
-    def mask(self) -> torch.tensor:
+    def device(self) -> str:
+        return self._find_common_device()
+
+    @property
+    def mask(self) -> torch.Tensor:
         return self._mask
 
     @mask.setter
-    def mask(self, new_mask: torch.tensor):
+    def mask(self, new_mask: torch.Tensor):
         self._mask = new_mask.to(self.device).bool().to(self.c.dtype) #Ensures it's all 1s and 0s
+
+    @property
+    def normalizer(self) -> torch.Tensor:
+        return self._normalizer
+
+    @property
+    def rescale(self):
+        return self._rescale
+
+    @rescale.setter
+    def rescale(self, new_value: bool):
+        self._rescale = new_value
 
     @property
     def contours(self) -> torch.sparse_coo_tensor:
@@ -129,7 +163,7 @@ class ACArray(FactorizedVideo):
         return self._contours
 
     @property
-    def centers(self) -> torch.tensor:
+    def centers(self) -> torch.Tensor:
         """
         Returns a (num_signals, 2) shaped tensor describing the height, width dimensions of each signals spatial center
             of mass. The center of mass might not be on an active pixel, but this is ok
@@ -168,7 +202,7 @@ class ACArray(FactorizedVideo):
         return self._centers
 
     @property
-    def bbox(self) -> torch.tensor:
+    def bbox(self) -> torch.Tensor:
         """
         Returns a torch tensor of shape (num_signals, 4). Each row contains 4 elements a1, a2, b1, b2 which define a bounding box
             of a neuron image like img[a1:a2, b1:b2]
@@ -205,7 +239,7 @@ class ACArray(FactorizedVideo):
 
 
     @property
-    def c(self) -> torch.tensor:
+    def c(self) -> torch.Tensor:
         """
         return temporal time courses of all signals, shape (frames, components)
         """
@@ -263,7 +297,7 @@ class ACArray(FactorizedVideo):
     def getitem_tensor(
         self,
         item: Union[int, list, np.ndarray, Tuple[Union[int, np.ndarray, slice, range]]],
-    ) -> torch.tensor:
+    ) -> torch.Tensor:
         # Step 1: index the frames (dimension 0)
         frame_indexer, item = self._parse_indices(item)
 
@@ -291,6 +325,9 @@ class ACArray(FactorizedVideo):
             product = torch.sparse.mm(a_crop, c_crop.T)
             product = product.reshape((implied_fov[0], implied_fov[1], -1))
             product = product.permute(2, 0, 1)
+
+        if self.normalizer is not None and self.rescale:
+            product *= self._normalizer[None, :, :]
 
         return product
 

--- a/masknmf/demixing/demixing_arrays/ac_array.py
+++ b/masknmf/demixing/demixing_arrays/ac_array.py
@@ -76,8 +76,13 @@ class ACArray(ArrayLike):
     def device(self):
         return self.flyweight.device
 
+
     def to(self, new_device):
-        self._flyweight.to(new_device)
+        if self._flyweight.device != new_device:
+            self._flyweight.to(new_device)
+        self._move_local_tensors(new_device)
+
+    def _move_local_tensors(self, new_device: str):
         self._pixel_mat = self._pixel_mat.to(new_device)
         self._mask = self._mask.to(new_device)
         self._default_normalizer = self._default_normalizer.to(new_device)
@@ -95,6 +100,7 @@ class ACArray(ArrayLike):
     def normalizer(self) -> torch.Tensor:
         if not hasattr(self.flyweight, "normalizer"):
             return self._default_normalizer
+        return self.flyweight.normalizer
 
     @property
     def rescale(self):
@@ -323,6 +329,7 @@ class ACArray(ArrayLike):
         if isinstance(item, tuple) and check_spatial_crop_effect(item[1:3], self.shape[1:3]):
 
             pixel_space_crop = self._pixel_mat[item[1:3]]
+            normalizer_crop = self.normalizer[item[1:3]][None, ...]
             a_indices = pixel_space_crop.flatten()
             a_crop = torch.index_select(self.a, 0, a_indices)
             implied_fov = pixel_space_crop.shape
@@ -332,13 +339,14 @@ class ACArray(ArrayLike):
 
         else:
             a_crop = self.a
+            normalizer_crop  = self.normalizer[None, :, :]
             implied_fov = self.shape[-2], self.shape[-1]
             product = torch.sparse.mm(a_crop, c_crop.T)
             product = product.reshape((implied_fov[0], implied_fov[1], -1))
             product = product.permute(2, 0, 1)
 
         if self.rescale:
-            product *= self.normalizer[None, :, :]
+            product *= normalizer_crop
 
         return product
 

--- a/masknmf/demixing/demixing_arrays/ac_array.py
+++ b/masknmf/demixing/demixing_arrays/ac_array.py
@@ -19,7 +19,7 @@ class ACArray(ArrayLike):
 
 
         self._flyweight = flyweight
-        self._validate_attributes(["a", "c"])
+        self.flyweight.validate_attributes(["a", "c"])
         num_frames = self.c.shape[0]
         self._shape = tuple(map(int, (num_frames, *fov_shape)))
 
@@ -67,11 +67,6 @@ class ACArray(ArrayLike):
                    flyweight,
                    rescale=rescale)
 
-
-    def _validate_attributes(self, attr_list):
-        for name in attr_list:
-            if not hasattr(self.flyweight, name):
-                raise ValueError(f"Required attribute: {name} missing from constructor")
 
     @property
     def flyweight(self) -> TensorFlyWeight:

--- a/masknmf/demixing/demixing_arrays/ac_array.py
+++ b/masknmf/demixing/demixing_arrays/ac_array.py
@@ -80,6 +80,7 @@ class ACArray(ArrayLike):
         self._flyweight.to(new_device)
         self._pixel_mat = self._pixel_mat.to(new_device)
         self._mask = self._mask.to(new_device)
+        self._default_normalizer = self._default_normalizer.to(new_device)
 
 
     @property

--- a/masknmf/demixing/demixing_arrays/ac_array.py
+++ b/masknmf/demixing/demixing_arrays/ac_array.py
@@ -1,10 +1,10 @@
 from typing import *
 import numpy as np
-from masknmf.arrays.array_interfaces import FactorizedVideo
+from masknmf.arrays.array_interfaces import ArrayLike, TensorFlyWeight
 import torch
 from masknmf.demixing.demixing_arrays.demixing_array_utils import check_spatial_crop_effect
 
-class ACArray(FactorizedVideo):
+class ACArray(ArrayLike):
     """
     Factorized video for the spatial and temporal extracted sources from the data
     Computations happen transparently on GPU, if device = 'cuda' is specified
@@ -13,12 +13,37 @@ class ACArray(FactorizedVideo):
     def __init__(
         self,
         fov_shape: tuple[int, int],
-        a: torch.sparse_coo_tensor,
-        c: torch.Tensor,
-        normalizer: Optional[torch.Tensor] = None,
+        flyweight: TensorFlyWeight,
         rescale: bool = False
     ):
-        DATA_ARRAYS = ["a", "c"]
+
+
+        self._flyweight = flyweight
+        self._validate_attributes(["a", "c"])
+        num_frames = self.c.shape[0]
+        self._shape = tuple(map(int, (num_frames, *fov_shape)))
+
+        self._pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
+        self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
+        self._centers = None
+        self._bbox = None
+        self._contours = None
+
+        self._rescale = rescale
+        self._default_normalizer = torch.ones(self.shape[1], self.shape[2], device=self.device).float()
+        if hasattr(self.flyweight, "normalizer"):
+            if self.flyweight.normalizer.shape[0] != self.shape[1] or self.flyweight.normalizer.shape[1] != self.shape[2]:
+                raise ValueError("Normalizer from flyweight had dimensions not equal to the fov dimensions")
+
+    @classmethod
+    def from_tensors(cls,
+                     fov_shape: tuple[int, int],
+                     a: torch.sparse_coo_tensor,
+                     c: torch.Tensor,
+                     normalizer: Optional[torch.Tensor],
+                     rescale: bool = False
+                     ):
         """
         Args:
             fov_shape (tuple): (fov_dim1, fov_dim2)
@@ -28,43 +53,39 @@ class ACArray(FactorizedVideo):
                 value to obtain results in the "raw data" space.
             rescale (bool): Whether or not to rescale the data to the raw data space. This determines the output of getitem
         """
+        flyweight = TensorFlyWeight(a=a, c=c, normalizer=normalizer)
+        return cls(fov_shape,
+                   flyweight,
+                   rescale=rescale)
 
-        self._a = a.coalesce()
-        self._c = c
-
-        num_frames = c.shape[0]
-        self._shape = tuple(map(int, (num_frames, *fov_shape)))
-        self.pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(
-            self.shape[1], self.shape[2])
-        self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
-        self._centers = None
-        self._bbox = None
-        self._contours = None
-
-        self._rescale = rescale
-        self._normalizer = normalizer
-        if self._normalizer is not None:
-            if self._normalizer.shape[0] != self.shape[1] or self._normalizer.shape[1] != self.shape[2]:
-                raise ValueError("Normalizer had dimensions not equal to the fov")
+    @classmethod
+    def from_flyweight(cls,
+                       fov_shape: tuple[int, int],
+                       flyweight: TensorFlyWeight,
+                       rescale: bool = False):
+        return cls(fov_shape,
+                   flyweight,
+                   rescale=rescale)
 
 
-    def _find_common_device(self):
-        """
-        Finds the common device that for all data tensors. Throws error if no such device exists
-        """
-        device=None
-        for i, name in enumerate(DATA_ARRAYS):
-            arr = getattr(self, name)
-            if i == 0:
-                device = arr.device
-            else:
-                if not arr.device == device:
-                    raise ValueError("Not all tensors in fluctuating background array are on same device")
-        return device
+    def _validate_attributes(self, attr_list):
+        for name in attr_list:
+            if not hasattr(self.flyweight, name):
+                raise ValueError(f"Required attribute: {name} missing from constructor")
 
     @property
-    def device(self) -> str:
-        return self._find_common_device()
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
+
+    @property
+    def device(self):
+        return self.flyweight.device
+
+    def to(self, new_device):
+        self._flyweight.to(new_device)
+        self._pixel_mat = self._pixel_mat.to(new_device)
+        self._mask = self._mask.to(new_device)
+
 
     @property
     def mask(self) -> torch.Tensor:
@@ -76,7 +97,8 @@ class ACArray(FactorizedVideo):
 
     @property
     def normalizer(self) -> torch.Tensor:
-        return self._normalizer
+        if not hasattr(self.flyweight, "normalizer"):
+            return self._default_normalizer
 
     @property
     def rescale(self):
@@ -243,14 +265,14 @@ class ACArray(FactorizedVideo):
         """
         return temporal time courses of all signals, shape (frames, components)
         """
-        return self._c
+        return self.flyweight.c
 
     @property
     def a(self) -> torch.sparse_coo_tensor:
         """
         return spatial profiles of all signals as sparse matrix, shape (pixels, components)
         """
-        return self._a
+        return self.flyweight.a
 
     def export_a(self) -> np.ndarray:
         """
@@ -265,13 +287,6 @@ class ACArray(FactorizedVideo):
         returns the temporal traces, where each trace is a n_frames-shaped time series. output shape (n_frames, n_components)
         """
         return self.c.cpu().numpy()
-
-    @property
-    def order(self) -> str:
-        """
-        The spatial data is "flattened" from 2D into 1D. This specifies the order ("F" for column-major or "C" for row-major) in which reshaping happened.
-        """
-        return self._order
 
     @property
     def dtype(self) -> str:
@@ -326,8 +341,8 @@ class ACArray(FactorizedVideo):
             product = product.reshape((implied_fov[0], implied_fov[1], -1))
             product = product.permute(2, 0, 1)
 
-        if self.normalizer is not None and self.rescale:
-            product *= self._normalizer[None, :, :]
+        if self.rescale:
+            product *= self.normalizer[None, :, :]
 
         return product
 

--- a/masknmf/demixing/demixing_arrays/ac_array.py
+++ b/masknmf/demixing/demixing_arrays/ac_array.py
@@ -23,7 +23,7 @@ class ACArray(ArrayLike):
         num_frames = self.c.shape[0]
         self._shape = tuple(map(int, (num_frames, *fov_shape)))
 
-        self._pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(
+        self._pixel_mat = torch.arange(self.shape[1] * self.shape[2], device=self.device, dtype=torch.long).reshape(
             self.shape[1], self.shape[2])
         self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
         self._centers = None
@@ -313,8 +313,8 @@ class ACArray(ArrayLike):
         frame_indexer, item = self._parse_indices(item)
 
         # Step 3: Now slice the data with frame_indexer (careful: if the ndims has shrunk, add a dim)
-        c_crop = self._c[frame_indexer, :]
-        if c_crop.ndim < self._c.ndim:
+        c_crop = self.c[frame_indexer, :]
+        if c_crop.ndim < self.c.ndim:
             c_crop = c_crop.unsqueeze(0)
 
         c_crop = c_crop * self._mask[None, :]
@@ -322,16 +322,16 @@ class ACArray(ArrayLike):
         # Step 4: First do spatial subselection before multiplying by c
         if isinstance(item, tuple) and check_spatial_crop_effect(item[1:3], self.shape[1:3]):
 
-            pixel_space_crop = self.pixel_mat[item[1:3]]
+            pixel_space_crop = self._pixel_mat[item[1:3]]
             a_indices = pixel_space_crop.flatten()
-            a_crop = torch.index_select(self._a, 0, a_indices)
+            a_crop = torch.index_select(self.a, 0, a_indices)
             implied_fov = pixel_space_crop.shape
             product = torch.sparse.mm(a_crop, c_crop.T)
             product = product.reshape(implied_fov + (-1,))
             product = product.permute(-1, *range(product.ndim - 1))
 
         else:
-            a_crop = self._a
+            a_crop = self.a
             implied_fov = self.shape[-2], self.shape[-1]
             product = torch.sparse.mm(a_crop, c_crop.T)
             product = product.reshape((implied_fov[0], implied_fov[1], -1))

--- a/masknmf/demixing/demixing_arrays/colorful_ac_array.py
+++ b/masknmf/demixing/demixing_arrays/colorful_ac_array.py
@@ -26,7 +26,7 @@ class ColorfulACArray(ArrayLike):
         self._c_minsub = self.c - torch.amin(self.c, dim=0, keepdim=True)
         fov_shape = tuple(map(int, fov_shape))
         self._shape = (t, *fov_shape, 3)
-        self._pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+        self._pixel_mat = torch.arange(self.shape[1] * self.shape[2], device=self.device, dtype=torch.long).reshape(
             self.shape[1], self.shape[2])
         self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
 
@@ -81,6 +81,9 @@ class ColorfulACArray(ArrayLike):
             if not hasattr(self.flyweight, name):
                 raise ValueError(f"Required attribute: {name} missing from constructor")
 
+    @property
+    def device(self) -> str:
+        return self.flyweight.device
 
     @property
     def a(self) -> torch.sparse_coo_tensor:

--- a/masknmf/demixing/demixing_arrays/colorful_ac_array.py
+++ b/masknmf/demixing/demixing_arrays/colorful_ac_array.py
@@ -8,6 +8,8 @@ class ColorfulACArray(FactorizedVideo):
     """
     Factorized video for the spatial and temporal extracted sources from the data
     """
+    DATA_ARRAYS = ["a",
+                   "c"]
 
     def __init__(
         self,
@@ -30,11 +32,10 @@ class ColorfulACArray(FactorizedVideo):
         self._c = c - torch.amin(c, dim=0, keepdim=True)
         if not (self.a.device == self.c.device):
             raise ValueError(f"Input tensors not on same device")
-        self._device = self.a.device
         fov_shape = tuple(map(int, fov_shape))
         self._shape = (t, *fov_shape, 3)
-        self.pixel_mat = np.arange(np.prod(self.shape[1:3])).reshape([self.shape[1], self.shape[2]])
-        self.pixel_mat = torch.from_numpy(self.pixel_mat).long().to(self.device)
+        self.pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
         self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
 
         ## Establish the coloring scheme
@@ -44,20 +45,39 @@ class ColorfulACArray(FactorizedVideo):
         color_sum = np.sum(colors, axis=1, keepdims=True)
         self._colors = torch.from_numpy(colors / color_sum).to(self.device).float()
 
+
+    def _find_common_device(self):
+        """
+        Finds the common device that for all data tensors. Throws error if no such device exists
+        """
+        device=None
+        for i, name in enumerate(DATA_ARRAYS):
+            arr = getattr(self, name)
+            if i == 0:
+                device = arr.device
+            else:
+                if not arr.device == device:
+                    raise ValueError("Not all tensors in fluctuating background array are on same device")
+        return device
+
+    @property
+    def device(self) -> str:
+        return self._find_common_device()
+
     @property
     def a(self) -> torch.sparse_coo_tensor:
         return self._a
 
     @property
-    def c(self) -> torch.tensor:
+    def c(self) -> torch.Tensor:
         return self._c
 
     @property
-    def mask(self) -> torch.tensor:
+    def mask(self) -> torch.Tensor:
         return self._mask
 
     @mask.setter
-    def mask(self, new_mask: torch.tensor):
+    def mask(self, new_mask: torch.Tensor):
         self._mask = new_mask.to(self.device).bool().to(self.c.dtype) #Ensures it's all 1s and 0s
 
     @property
@@ -65,7 +85,7 @@ class ColorfulACArray(FactorizedVideo):
         return self._device
 
     @property
-    def colors(self) -> torch.tensor:
+    def colors(self) -> torch.Tensor:
         """
         Colors used for each neuron
 
@@ -75,7 +95,7 @@ class ColorfulACArray(FactorizedVideo):
         return self._colors
 
     @colors.setter
-    def colors(self, new_colors: torch.tensor):
+    def colors(self, new_colors: torch.Tensor):
         """
         Updates the colors used here
         Args:
@@ -104,7 +124,7 @@ class ColorfulACArray(FactorizedVideo):
         """
         return len(self.shape)
 
-    def compute_mip(self) -> torch.tensor:
+    def compute_mip(self) -> torch.Tensor:
         updated_coloring = self.colors * torch.amax(self.c, dim=0, keepdims = True).T #(num_neurons, 3)
         updated_coloring = updated_coloring * self.mask[:, None].float()
         mip_image = torch.sparse.mm(self.a, updated_coloring)

--- a/masknmf/demixing/demixing_arrays/colorful_ac_array.py
+++ b/masknmf/demixing/demixing_arrays/colorful_ac_array.py
@@ -21,7 +21,7 @@ class ColorfulACArray(ArrayLike):
         """
 
         self._flyweight = flyweight
-        self._validate_attributes(["a", "c"])
+        self.flyweight.validate_attributes(["a", "c"])
         t = self.c.shape[0]
         self._c_minsub = self.c - torch.amin(self.c, dim=0, keepdim=True)
         fov_shape = tuple(map(int, fov_shape))

--- a/masknmf/demixing/demixing_arrays/colorful_ac_array.py
+++ b/masknmf/demixing/demixing_arrays/colorful_ac_array.py
@@ -75,12 +75,6 @@ class ColorfulACArray(ArrayLike):
                    min_color=min_color,
                    max_color=max_color)
 
-
-    def _validate_attributes(self, attr_list):
-        for name in attr_list:
-            if not hasattr(self.flyweight, name):
-                raise ValueError(f"Required attribute: {name} missing from constructor")
-
     @property
     def device(self) -> str:
         return self.flyweight.device
@@ -94,7 +88,11 @@ class ColorfulACArray(ArrayLike):
         return self.flyweight.c
 
     def to(self, new_device):
-        self._flyweight.to(new_device)
+        if self._flyweight.device != new_device:
+            self._flyweight.to(new_device)
+        self._move_local_tensors(new_device)
+
+    def _move_local_tensors(self, new_device):
         self._pixel_mat = self._pixel_mat.to(new_device)
         self._c_minsub = self._c_minsub.to(new_device)
         self._mask = self._mask.to(new_device)

--- a/masknmf/demixing/demixing_arrays/colorful_ac_array.py
+++ b/masknmf/demixing/demixing_arrays/colorful_ac_array.py
@@ -1,24 +1,54 @@
 from typing import *
 import numpy as np
-from masknmf.arrays.array_interfaces import FactorizedVideo
+from masknmf.arrays.array_interfaces import ArrayLike, TensorFlyWeight
 import torch
 from masknmf.demixing.demixing_arrays.demixing_array_utils import check_spatial_crop_effect
 
-class ColorfulACArray(FactorizedVideo):
+class ColorfulACArray(ArrayLike):
     """
     Factorized video for the spatial and temporal extracted sources from the data
     """
-    DATA_ARRAYS = ["a",
-                   "c"]
 
     def __init__(
         self,
         fov_shape: Tuple[int, int],
-        a: torch.sparse_coo_tensor,
-        c: torch.tensor,
+        flyweight: TensorFlyWeight,
         min_color: int = 30,
         max_color: int = 255,
     ):
+        """
+        See from_tensors class method for documentation
+        """
+
+        self._flyweight = flyweight
+        self._validate_attributes(["a", "c"])
+        t = self.c.shape[0]
+        self._c_minsub = self.c - torch.amin(self.c, dim=0, keepdim=True)
+        fov_shape = tuple(map(int, fov_shape))
+        self._shape = (t, *fov_shape, 3)
+        self._pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
+        self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
+
+        ## Establish the coloring scheme
+        num_neurons = self.c.shape[1]
+        colors = np.random.uniform(low=min_color, high=max_color, size=num_neurons * 3)
+        colors = colors.reshape((num_neurons, 3))
+        color_sum = np.sum(colors, axis=1, keepdims=True)
+        self._colors = torch.from_numpy(colors / color_sum).to(self.device).float()
+
+    @property
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
+
+    @classmethod
+    def from_tensors(cls,
+                     fov_shape: tuple[int, int],
+                     a: torch.sparse_coo_tensor,
+                     c: torch.Tensor,
+                     min_color: int = 30,
+                     max_color: int = 255,
+                     ):
         """
         Args:
             fov_shape (tuple): (fov_dim1, fov_dim2)
@@ -27,50 +57,45 @@ class ColorfulACArray(FactorizedVideo):
             min_color (int): Minimum RGB value (from 0 to 255)
             max_color (int): Maximum RGB value (from 0 to 255)
         """
-        t = c.shape[0]
-        self._a = a
-        self._c = c - torch.amin(c, dim=0, keepdim=True)
-        if not (self.a.device == self.c.device):
-            raise ValueError(f"Input tensors not on same device")
-        fov_shape = tuple(map(int, fov_shape))
-        self._shape = (t, *fov_shape, 3)
-        self.pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
-            self.shape[1], self.shape[2])
-        self._mask = torch.ones(self.a.shape[1], device=self.device, dtype=self.c.dtype)
+        flyweight = TensorFlyWeight(a=a, c=c)
+        return cls(fov_shape,
+                   flyweight,
+                   min_color=min_color,
+                   max_color=max_color)
 
-        ## Establish the coloring scheme
-        num_neurons = c.shape[1]
-        colors = np.random.uniform(low=min_color, high=max_color, size=num_neurons * 3)
-        colors = colors.reshape((num_neurons, 3))
-        color_sum = np.sum(colors, axis=1, keepdims=True)
-        self._colors = torch.from_numpy(colors / color_sum).to(self.device).float()
+    @classmethod
+    def from_flyweight(cls,
+                       fov_shape,
+                       flyweight: TensorFlyWeight,
+                       min_color: int = 30,
+                       max_color: int = 255,
+                       ):
+        return cls(fov_shape,
+                   flyweight,
+                   min_color=min_color,
+                   max_color=max_color)
 
 
-    def _find_common_device(self):
-        """
-        Finds the common device that for all data tensors. Throws error if no such device exists
-        """
-        device=None
-        for i, name in enumerate(DATA_ARRAYS):
-            arr = getattr(self, name)
-            if i == 0:
-                device = arr.device
-            else:
-                if not arr.device == device:
-                    raise ValueError("Not all tensors in fluctuating background array are on same device")
-        return device
+    def _validate_attributes(self, attr_list):
+        for name in attr_list:
+            if not hasattr(self.flyweight, name):
+                raise ValueError(f"Required attribute: {name} missing from constructor")
 
-    @property
-    def device(self) -> str:
-        return self._find_common_device()
 
     @property
     def a(self) -> torch.sparse_coo_tensor:
-        return self._a
+        return self.flyweight.a
 
     @property
     def c(self) -> torch.Tensor:
-        return self._c
+        return self.flyweight.c
+
+    def to(self, new_device):
+        self._flyweight.to(new_device)
+        self._pixel_mat = self._pixel_mat.to(new_device)
+        self._c_minsub = self._c_minsub.to(new_device)
+        self._mask = self._mask.to(new_device)
+        self._colors = self._colors.to(new_device)
 
     @property
     def mask(self) -> torch.Tensor:
@@ -79,10 +104,6 @@ class ColorfulACArray(FactorizedVideo):
     @mask.setter
     def mask(self, new_mask: torch.Tensor):
         self._mask = new_mask.to(self.device).bool().to(self.c.dtype) #Ensures it's all 1s and 0s
-
-    @property
-    def device(self) -> str:
-        return self._device
 
     @property
     def colors(self) -> torch.Tensor:
@@ -99,7 +120,7 @@ class ColorfulACArray(FactorizedVideo):
         """
         Updates the colors used here
         Args:
-            new_colors (torch.tensor): Shape (num_neurons, 3)
+            new_colors (torch.Tensor): Shape (num_neurons, 3)
         """
         self._colors = new_colors.to(self.device).to(self.c.dtype)
 
@@ -143,7 +164,7 @@ class ColorfulACArray(FactorizedVideo):
         frame_indexer, item = self._parse_indices(item)
 
         # Step 3: Now slice the data with frame_indexer (careful: if the ndims has shrunk, add a dim)
-        c_crop = self.c[frame_indexer, :]
+        c_crop = self._c_minsub[frame_indexer, :]
         if c_crop.ndim < self.c.ndim:
             c_crop = c_crop[None, :]
 
@@ -154,9 +175,9 @@ class ColorfulACArray(FactorizedVideo):
         if isinstance(item, tuple) and check_spatial_crop_effect(
             item[1:3], self.shape[1:3]
         ):
-            pixel_space_crop = self.pixel_mat[item[1:3]]
+            pixel_space_crop = self._pixel_mat[item[1:3]]
             a_indices = pixel_space_crop.flatten()
-            a_crop = torch.index_select(self._a, 0, a_indices)
+            a_crop = torch.index_select(self.a, 0, a_indices)
             implied_fov = pixel_space_crop.shape
             product_list = []
             for k in range(3):
@@ -167,7 +188,7 @@ class ColorfulACArray(FactorizedVideo):
             product = product.reshape(implied_fov + (c_crop.shape[1],) + (3,))
             product = product.permute(product.ndim - 2, *range(product.ndim - 2), 3)
         else:
-            a_crop = self._a
+            a_crop = self.a
             implied_fov = self.shape[1], self.shape[2]
 
             product_list = []

--- a/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
+++ b/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
@@ -11,55 +11,62 @@ class FluctuatingBackgroundArray(FactorizedVideo):
     "a" is the matrix of spatial profiles
     "c" is the matrix of temporal profiles
     """
+    DATA_ARRAYS = ["u", "a", "b"]
 
     def __init__(
         self,
         fov_shape: Tuple[int, int],
-        order: str,
         u: torch.sparse_coo_tensor,
-        a: torch.tensor,
-        b: torch.tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
     ):
         """
         The background movie can be factorized as the matrix product Uab,
         where u, and v are the standard matrices from the pmd decomposition,
         Args:
             fov_shape (tuple): (fov_dim1, fov_dim2)
-            order (str): Order to reshape arrays from 1D to 2D
             u (torch.sparse_coo_tensor): shape (pixels, rank1)
-            a (torch.tensor): shape (PMD rank, background_rank)
-            b (torch.tensor): shape (background_rank, num_frames)
+            a (torch.Tensor): shape (PMD rank, background_rank)
+            b (torch.Tensor): shape (background_rank, num_frames)
         """
         t = b.shape[1]
         self._shape = (t,) + fov_shape
 
         self._u = u
         self._b = b
-        self._a= a
+        self._a = a
 
-        if not (self.u.device == self.a.device == self.b.device):
-            raise ValueError(f"Some input tensors are not on the same device")
-        self._device = self.u.device
-        self.pixel_mat = np.arange(np.prod(self.shape[1:])).reshape(
-            [self.shape[1], self.shape[2]], order=order
-        )
-        self.pixel_mat = torch.from_numpy(self.pixel_mat).long().to(self.device)
-        self._order = order
+        self.pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(self.shape[1], self.shape[2])
+
+
+    def _find_common_device(self):
+        """
+        Finds the common device that for all data tensors. Throws error if no such device exists
+        """
+        device=None
+        for i, name in enumerate(DATA_ARRAYS):
+            arr = getattr(self, name)
+            if i == 0:
+                device = arr.device
+            else:
+                if not arr.device == device:
+                    raise ValueError("Not all tensors in fluctuating background array are on same device")
+        return device
 
     @property
     def device(self) -> str:
-        return self._device
+        return self._find_common_device()
 
     @property
     def u(self) -> torch.sparse_coo_tensor:
         return self._u
 
     @property
-    def a(self) -> torch.tensor:
+    def a(self) -> torch.Tensor:
         return self._a
 
     @property
-    def b(self) -> torch.tensor:
+    def b(self) -> torch.Tensor:
         return self._b
 
     @property
@@ -75,13 +82,6 @@ class FluctuatingBackgroundArray(FactorizedVideo):
         Array shape (n_frames, dims_x, dims_y)
         """
         return self._shape
-
-    @property
-    def order(self) -> str:
-        """
-        The spatial data is "flattened" from 2D into 1D. This specifies the order ("F" for column-major or "C" for row-major) in which reshaping happened.
-        """
-        return self._order
 
     @property
     def ndim(self) -> int:
@@ -129,12 +129,10 @@ class FluctuatingBackgroundArray(FactorizedVideo):
             u_indices = pixel_space_crop.flatten()
             u_crop = torch.index_select(self._u, 0, u_indices)
             implied_fov = pixel_space_crop.shape
-            used_order = "C"  # Torch order here by default is C
 
         else:
             u_crop = self._u
             implied_fov = self.shape[1], self.shape[2]
-            used_order = self.order
 
         # Temporal term is guaranteed to have nonzero "T" dimension below
         if np.prod(implied_fov) <= b_crop.shape[1]:
@@ -145,12 +143,9 @@ class FluctuatingBackgroundArray(FactorizedVideo):
             product = torch.matmul(self.a, b_crop)
             product = torch.sparse.mm(u_crop, product)
 
-        if used_order == "F":
-            product = product.T.reshape((-1, implied_fov[1], implied_fov[0]))
-            product = product.permute((0, 2, 1))
-        else:  # order is "C"
-            product = product.reshape((implied_fov[0], implied_fov[1], -1))
-            product = product.permute(-1, *range(product.ndim - 1))
+
+        product = product.reshape((implied_fov[0], implied_fov[1], -1))
+        product = product.permute(-1, *range(product.ndim - 1))
 
         return product
 

--- a/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
+++ b/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
@@ -1,73 +1,100 @@
 from typing import *
 import numpy as np
-from masknmf.arrays.array_interfaces import FactorizedVideo
+from masknmf.arrays.array_interfaces import ArrayLike, TensorFlyWeight
 import torch
 from masknmf.demixing.demixing_arrays.demixing_array_utils import check_spatial_crop_effect
 
-class FluctuatingBackgroundArray(FactorizedVideo):
+class FluctuatingBackgroundArray(ArrayLike):
     """
     Factorized video for the spatial and temporal extracted sources from the data
 
-    "a" is the matrix of spatial profiles
-    "c" is the matrix of temporal profiles
     """
-    DATA_ARRAYS = ["u", "a", "b"]
 
     def __init__(
         self,
         fov_shape: Tuple[int, int],
-        u: torch.sparse_coo_tensor,
-        a: torch.Tensor,
-        b: torch.Tensor,
+        flyweight: TensorFlyWeight,
+        rescale: bool = False,
     ):
+        """
+        See from_tensors for parameter documentation
+        """
+        self._flyweight = flyweight
+        self.flyweight.validate_attributes(['u', 'factorized_bkgd_term1', 'factorized_bkgd_term2'])
+        t = self.factorized_bkgd_term2.shape[1]
+        self._shape = (t,) + fov_shape
+        self._pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(self.shape[1], self.shape[2])
+
+        self._default_normalizer = torch.ones(self.shape[1], self.shape[2], device=self.device).float()
+        if hasattr(self.flyweight, "normalizer"):
+            if self.flyweight.normalizer.shape[0] != self.shape[1] or self.flyweight.normalizer.shape[1] != self.shape[2]:
+                raise ValueError("Normalizer from flyweight had dimensions not equal to the fov dimensions")
+
+        self._rescale = rescale
+
+    @classmethod
+    def from_tensors(cls,
+                     fov_shape: tuple[int, int],
+                     u: torch.sparse_coo_tensor,
+                     factorized_bkgd_term1: torch.Tensor,
+                     factorized_bkgd_term2: torch.Tensor,
+                     normalizer: Optional[torch.Tensor],
+                     rescale: bool = False
+                     ):
         """
         The background movie can be factorized as the matrix product Uab,
         where u, and v are the standard matrices from the pmd decomposition,
         Args:
             fov_shape (tuple): (fov_dim1, fov_dim2)
             u (torch.sparse_coo_tensor): shape (pixels, rank1)
-            a (torch.Tensor): shape (PMD rank, background_rank)
-            b (torch.Tensor): shape (background_rank, num_frames)
+            factorized_bkgd_term1 (torch.Tensor): shape (PMD rank, background_rank)
+            factorized_bkgd_term2 (torch.Tensor): shape (background_rank, num_frames)
+            normalizer (Optional[torch.Tensor]): Demixing is performed in a normalized space; this tensor of shape (height, width) specifies pixel-wise normalization
+            rescale (bool): Whether or not to rescale the data to the original data space (i.e. multiply pixelwise by the normalizer)
         """
-        t = b.shape[1]
-        self._shape = (t,) + fov_shape
+        flyweight = TensorFlyWeight(u=u,
+                                    factorized_bkgd_term1=factorized_bkgd_term1,
+                                    factorized_bkgd_term2=factorized_bkgd_term2,
+                                    normalizer=normalizer)
+        return cls(fov_shape,
+                   flyweight,
+                   rescale=rescale)
 
-        self._u = u
-        self._b = b
-        self._a = a
-
-        self.pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(self.shape[1], self.shape[2])
-
-
-    def _find_common_device(self):
-        """
-        Finds the common device that for all data tensors. Throws error if no such device exists
-        """
-        device=None
-        for i, name in enumerate(DATA_ARRAYS):
-            arr = getattr(self, name)
-            if i == 0:
-                device = arr.device
-            else:
-                if not arr.device == device:
-                    raise ValueError("Not all tensors in fluctuating background array are on same device")
-        return device
-
-    @property
-    def device(self) -> str:
-        return self._find_common_device()
+    @classmethod
+    def from_flyweight(cls,
+                       fov_shape: tuple[int, int],
+                       flyweight: TensorFlyWeight,
+                       rescale: bool = False
+                       ):
+        return cls(fov_shape,
+                   flyweight,
+                   rescale=rescale)
 
     @property
     def u(self) -> torch.sparse_coo_tensor:
-        return self._u
+        return self.flyweight.u
 
     @property
-    def a(self) -> torch.Tensor:
-        return self._a
+    def factorized_bkgd_term1(self) -> torch.Tensor:
+        return self.flyweight.factorized_bkgd_term1
 
     @property
-    def b(self) -> torch.Tensor:
-        return self._b
+    def factorized_bkgd_term2(self) -> torch.Tensor:
+        return self.flyweight.factorized_bkgd_term2
+
+    @property
+    def normalizer(self) -> torch.Tensor:
+        if not hasattr(self.flyweight, "normalizer"):
+            return self._default_normalizer
+
+    @property
+    def device(self):
+        return self.flyweight.device
+
+    def to(self, new_device: str):
+        self._flyweight.to(new_device)
+        self._pixel_mat.to(new_device)
+        self._default_normalizer.to(new_device)
 
     @property
     def dtype(self) -> str:
@@ -90,6 +117,15 @@ class FluctuatingBackgroundArray(FactorizedVideo):
         """
         return len(self.shape)
 
+
+    @property
+    def rescale(self):
+        return self._rescale
+
+    @rescale.setter
+    def rescale(self, new_value: bool):
+        self._rescale = new_value
+
     def getitem_tensor(
         self,
         item: Union[int, list, np.ndarray, Tuple[Union[int, np.ndarray, slice, range]]],
@@ -97,9 +133,9 @@ class FluctuatingBackgroundArray(FactorizedVideo):
         frame_indexer, item = self._parse_indices(item)
 
         # Step 3: Now slice the data with frame_indexer (careful: if the ndims has shrunk, add a dim)
-        b_crop = self.b[:, frame_indexer]
-        if b_crop.ndim < self.b.ndim:
-            b_crop = b_crop.unsqueeze(1)
+        factorized_bkgd_term2_crop = self.factorized_bkgd_term2[:, frame_indexer]
+        if factorized_bkgd_term2_crop.ndim < self.factorized_bkgd_term2.ndim:
+            factorized_bkgd_term2_crop = factorized_bkgd_term2_crop.unsqueeze(1)
 
         # Step 4: Deal with remaining indices after lazy computing the frame(s)
         if isinstance(item, tuple) and check_spatial_crop_effect(
@@ -125,27 +161,30 @@ class FluctuatingBackgroundArray(FactorizedVideo):
 
             spatial_crop_terms = (term_1, term_2)
 
-            pixel_space_crop = self.pixel_mat[spatial_crop_terms]
+            pixel_space_crop = self._pixel_mat[spatial_crop_terms]
             u_indices = pixel_space_crop.flatten()
-            u_crop = torch.index_select(self._u, 0, u_indices)
+            u_crop = torch.index_select(self.u, 0, u_indices)
             implied_fov = pixel_space_crop.shape
 
         else:
-            u_crop = self._u
+            u_crop = self.u
             implied_fov = self.shape[1], self.shape[2]
 
         # Temporal term is guaranteed to have nonzero "T" dimension below
-        if np.prod(implied_fov) <= b_crop.shape[1]:
-            product = torch.sparse.mm(u_crop, self.a)
-            product = torch.matmul(product, b_crop)
+        if np.prod(implied_fov) <= factorized_bkgd_term2_crop.shape[1]:
+            product = torch.sparse.mm(u_crop, self.factorized_bkgd_term1)
+            product = torch.matmul(product, factorized_bkgd_term2_crop)
 
         else:
-            product = torch.matmul(self.a, b_crop)
+            product = torch.matmul(self.factorized_bkgd_term1, factorized_bkgd_term2_crop)
             product = torch.sparse.mm(u_crop, product)
 
 
         product = product.reshape((implied_fov[0], implied_fov[1], -1))
         product = product.permute(-1, *range(product.ndim - 1))
+
+        if self.rescale:
+            product *= self.normalizer[None, :, :]
 
         return product
 

--- a/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
+++ b/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
@@ -89,16 +89,25 @@ class FluctuatingBackgroundArray(ArrayLike):
     @property
     def normalizer(self) -> torch.Tensor:
         if not hasattr(self.flyweight, "normalizer"):
-            return self._default_normalizer
+            return self._default_normalizer.to(self.device)
+        return self.flyweight.normalizer
 
     @property
     def device(self):
         return self.flyweight.device
 
     def to(self, new_device: str):
-        self._flyweight.to(new_device)
-        self._pixel_mat.to(new_device)
-        self._default_normalizer.to(new_device)
+        """
+        Note: tensors that are not managed by flyweight need to be consistently moved to the device that flyweight is on
+        in the getitem implementation
+        """
+        if self._flyweight.device != new_device:
+            self._flyweight.to(new_device)
+        self._move_local_tensors(new_device)
+
+    def _move_local_tensors(self, new_device: str):
+        self._pixel_mat = self._pixel_mat.to(new_device)
+        self._default_normalizer = self._default_normalizer.to(new_device)
 
     @property
     def dtype(self) -> str:
@@ -166,12 +175,14 @@ class FluctuatingBackgroundArray(ArrayLike):
             spatial_crop_terms = (term_1, term_2)
 
             pixel_space_crop = self._pixel_mat[spatial_crop_terms]
+            normalizer_crop = self.normalizer[spatial_crop_terms][None, ...]
             u_indices = pixel_space_crop.flatten()
             u_crop = torch.index_select(self.u, 0, u_indices)
             implied_fov = pixel_space_crop.shape
 
         else:
             u_crop = self.u
+            normalizer_crop = self.normalizer[None, ...]
             implied_fov = self.shape[1], self.shape[2]
 
         # Temporal term is guaranteed to have nonzero "T" dimension below
@@ -188,7 +199,7 @@ class FluctuatingBackgroundArray(ArrayLike):
         product = product.permute(-1, *range(product.ndim - 1))
 
         if self.rescale:
-            product *= self.normalizer[None, :, :]
+            product *= normalizer_crop
 
         return product
 

--- a/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
+++ b/masknmf/demixing/demixing_arrays/fluctuating_background_array.py
@@ -23,7 +23,7 @@ class FluctuatingBackgroundArray(ArrayLike):
         self.flyweight.validate_attributes(['u', 'factorized_bkgd_term1', 'factorized_bkgd_term2'])
         t = self.factorized_bkgd_term2.shape[1]
         self._shape = (t,) + fov_shape
-        self._pixel_mat = torch.arange(np.prod(self.shape[1:]), device=self.device, dtype=torch.long).reshape(self.shape[1], self.shape[2])
+        self._pixel_mat = torch.arange(self.shape[1] * self.shape[2], device=self.device, dtype=torch.long).reshape(self.shape[1], self.shape[2])
 
         self._default_normalizer = torch.ones(self.shape[1], self.shape[2], device=self.device).float()
         if hasattr(self.flyweight, "normalizer"):
@@ -69,6 +69,10 @@ class FluctuatingBackgroundArray(ArrayLike):
         return cls(fov_shape,
                    flyweight,
                    rescale=rescale)
+
+    @property
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
 
     @property
     def u(self) -> torch.sparse_coo_tensor:

--- a/masknmf/demixing/demixing_arrays/residual_array.py
+++ b/masknmf/demixing/demixing_arrays/residual_array.py
@@ -96,7 +96,7 @@ class ResidualArray(ArrayLike):
                 self.pmd_array.getitem_tensor(item)
                 - self.fluctuating_background_array.getitem_tensor(item)
                 - self.ac_array.getitem_tensor(item)
-                - self.baseline.getitem_tensor((slice(0, self.shape[1]), slice(0, self.shape[2])))[None, :]
+                - self.baseline.getitem_tensor((slice(0, self.shape[1]), slice(0, self.shape[2])))[None, ...]
             )
 
         return output.cpu().numpy()

--- a/masknmf/demixing/demixing_arrays/residual_array.py
+++ b/masknmf/demixing/demixing_arrays/residual_array.py
@@ -87,14 +87,14 @@ class ResidualArray(ArrayLike):
         if isinstance(item, tuple) and len(item) > 1:
             output = (
                 self.pmd_array.getitem_tensor(item)
-                - self.fluctuating_array.getitem_tensor(item)
+                - self.fluctuating_background_array.getitem_tensor(item)
                 - self.ac_array.getitem_tensor(item)
                 - self.baseline.getitem_tensor(item[1:])[None, ...]
             )
         else:
             output = (
                 self.pmd_array.getitem_tensor(item)
-                - self.fluctuating_array.getitem_tensor(item)
+                - self.fluctuating_background_array.getitem_tensor(item)
                 - self.ac_array.getitem_tensor(item)
                 - self.baseline.getitem_tensor((slice(0, self.shape[1]), slice(0, self.shape[2])))[None, :]
             )

--- a/masknmf/demixing/demixing_arrays/residual_array.py
+++ b/masknmf/demixing/demixing_arrays/residual_array.py
@@ -13,48 +13,77 @@ class ResidualArray(FactorizedVideo):
 
     def __init__(
         self,
-        pmd_arr: PMDArray,
-        ac_arr: ACArray,
-        fluctuating_arr: FluctuatingBackgroundArray,
-        baseline: torch.tensor,
+        pmd_array: PMDArray,
+        ac_array: ACArray,
+        fluctuating_background_array: FluctuatingBackgroundArray,
+        baseline: torch.Tensor,
     ):
         """
         Args:
-            pmd_arr (PMDArray)
-            ac_arr (ACArray)
-            fluctuating_arr (FluctuatingBackgroundArray)
-            baseline (torch.tensor): Shape (fov dim 1, fov dim 2)
+            pmd_array (PMDArray)
+            ac_array (ACArray)
+            fluctuating_array (FluctuatingBackgroundArray)
+            baseline (torch.Tensor): Shape (fov dim 1, fov dim 2)
         """
-        self.pmd_arr = pmd_arr
-        # Demixing is run on the U/V representation, without rescaling, so we set rescale = False here to make sure scales match
-        self.pmd_arr.rescale = False
-        self.ac_arr = ac_arr
-        self.baseline = baseline
-        self.fluctuating_arr = fluctuating_arr
 
-        if not (
-            self.pmd_arr.device
-            == self.ac_arr.device
-            == self.baseline.device
-            == self.fluctuating_arr.device
-        ):
-            raise ValueError(f"Input arrays not all on same device")
-        self._device = self.pmd_arr.device
-        self._shape = self.pmd_arr.shape
+        DATA_ARRAYS = ["pmd_array",
+                       "ac_array",
+                       "fluctuating_background_array",
+                       "baseline"]
+
+        self._pmd_array = pmd_array
+        # Demixing is run on the U/V representation, without rescaling, so we set rescale = False here to make sure scales match
+        self._pmd_array.rescale = False
+        self._ac_array = ac_array
+        self._baseline = baseline
+        self._fluctuating_background_array = fluctuating_background_array
+
+        #Check that all data is on same device
+        self._find_common_device()
+
+        self._shape = self.pmd_array.shape
+
+    def _find_common_device(self):
+        """
+        Finds the common device that for all data tensors. Throws error if no such device exists
+        """
+        device=None
+        for i, name in enumerate(DATA_ARRAYS):
+            arr = getattr(self, name)
+            if i == 0:
+                device = arr.device
+            else:
+                if not arr.device == device:
+                    raise ValueError("Not all tensors in fluctuating background array are on same device")
+        return device
+
+    @property
+    def device(self) -> str:
+        return self._find_common_device()
 
     @property
     def dtype(self) -> str:
         """
         data type, default np.float32
         """
-        return self.pmd_arr.dtype
+        return self.pmd_array.dtype
 
     @property
-    def device(self) -> str:
-        """
-        Returns the device that all the internal tensors are on at init time
-        """
-        return self._device
+    def pmd_array(self) -> PMDArray:
+        return self._pmd_array
+
+    @property
+    def ac_array(self) -> ACArray:
+        return self._ac_array
+
+    @property
+    def fluctuating_background_array(self) -> FluctuatingBackgroundArray:
+        return self._fluctuating_background_array
+
+    @property
+    def baseline(self) -> torch.Tensor:
+        return self._baseline
+
 
     @property
     def shape(self) -> Tuple[int, int, int]:
@@ -77,16 +106,16 @@ class ResidualArray(FactorizedVideo):
         # In this case there is spatial cropping
         if isinstance(item, tuple) and len(item) > 1:
             output = (
-                self.pmd_arr.getitem_tensor(item)
-                - self.fluctuating_arr.getitem_tensor(item)
-                - self.ac_arr.getitem_tensor(item)
+                self.pmd_array.getitem_tensor(item)
+                - self.fluctuating_array.getitem_tensor(item)
+                - self.ac_array.getitem_tensor(item)
                 - self.baseline[item[1:]][None, ...]
             )
         else:
             output = (
-                self.pmd_arr.getitem_tensor(item)
-                - self.fluctuating_arr.getitem_tensor(item)
-                - self.ac_arr.getitem_tensor(item)
+                self.pmd_array.getitem_tensor(item)
+                - self.fluctuating_array.getitem_tensor(item)
+                - self.ac_array.getitem_tensor(item)
                 - self.baseline[None, :]
             )
 

--- a/masknmf/demixing/demixing_arrays/residual_array.py
+++ b/masknmf/demixing/demixing_arrays/residual_array.py
@@ -1,12 +1,13 @@
 from typing import *
 import numpy as np
-from masknmf.arrays.array_interfaces import FactorizedVideo
+from masknmf.arrays.array_interfaces import ArrayLike
 from masknmf.compression.pmd_array import PMDArray
 from masknmf.demixing.demixing_arrays.ac_array import ACArray
 from masknmf.demixing.demixing_arrays.fluctuating_background_array import FluctuatingBackgroundArray
+from masknmf.demixing.demixing_arrays.static_baseline import StaticBackgroundArray
 import torch
 
-class ResidualArray(FactorizedVideo):
+class ResidualArray(ArrayLike):
     """
     Factorized video for the spatial and temporal extracted sources from the data
     """
@@ -16,51 +17,30 @@ class ResidualArray(FactorizedVideo):
         pmd_array: PMDArray,
         ac_array: ACArray,
         fluctuating_background_array: FluctuatingBackgroundArray,
-        baseline: torch.Tensor,
+        static_baseline_array: StaticBackgroundArray,
     ):
         """
         Args:
             pmd_array (PMDArray)
             ac_array (ACArray)
             fluctuating_array (FluctuatingBackgroundArray)
-            baseline (torch.Tensor): Shape (fov dim 1, fov dim 2)
+            baseline (StaticBackgroundArray): Shape (height, width)
         """
 
-        DATA_ARRAYS = ["pmd_array",
-                       "ac_array",
-                       "fluctuating_background_array",
-                       "baseline"]
-
         self._pmd_array = pmd_array
-        # Demixing is run on the U/V representation, without rescaling, so we set rescale = False here to make sure scales match
-        self._pmd_array.rescale = False
         self._ac_array = ac_array
-        self._baseline = baseline
+        self._baseline = static_baseline_array
         self._fluctuating_background_array = fluctuating_background_array
-
-        #Check that all data is on same device
-        self._find_common_device()
 
         self._shape = self.pmd_array.shape
 
-    def _find_common_device(self):
-        """
-        Finds the common device that for all data tensors. Throws error if no such device exists
-        """
-        device=None
-        for i, name in enumerate(DATA_ARRAYS):
-            arr = getattr(self, name)
-            if i == 0:
-                device = arr.device
-            else:
-                if not arr.device == device:
-                    raise ValueError("Not all tensors in fluctuating background array are on same device")
-        return device
-
     @property
     def device(self) -> str:
-        return self._find_common_device()
-
+        if self.pmd_array.device == self.ac_array.device == self.fluctuating_background_array.device == self.baseline.device:
+            return self.pmd_array.device
+        else:
+            raise ValueError("Not all arrays are on same device")
+        
     @property
     def dtype(self) -> str:
         """
@@ -81,7 +61,7 @@ class ResidualArray(FactorizedVideo):
         return self._fluctuating_background_array
 
     @property
-    def baseline(self) -> torch.Tensor:
+    def baseline(self) -> StaticBackgroundArray:
         return self._baseline
 
 
@@ -109,14 +89,14 @@ class ResidualArray(FactorizedVideo):
                 self.pmd_array.getitem_tensor(item)
                 - self.fluctuating_array.getitem_tensor(item)
                 - self.ac_array.getitem_tensor(item)
-                - self.baseline[item[1:]][None, ...]
+                - self.baseline.getitem_tensor(item[1:])[None, ...]
             )
         else:
             output = (
                 self.pmd_array.getitem_tensor(item)
                 - self.fluctuating_array.getitem_tensor(item)
                 - self.ac_array.getitem_tensor(item)
-                - self.baseline[None, :]
+                - self.baseline.getitem_tensor((slice(0, self.shape[1]), slice(0, self.shape[2])))[None, :]
             )
 
         return output.cpu().numpy()

--- a/masknmf/demixing/demixing_arrays/residual_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/residual_correlation_images.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import *
 import numpy as np
-from masknmf.arrays.array_interfaces import FactorizedVideo
+from masknmf.arrays.array_interfaces import ArrayLike, TensorFlyWeight
 import torch
 from masknmf.demixing.demixing_arrays.demixing_array_utils import check_spatial_crop_effect
 
@@ -11,18 +11,46 @@ class ResidCorrMode(Enum):
     RESIDUAL = 2
 
 
-class ResidualCorrelationImages(FactorizedVideo):
-    def __init__(
-        self,
+class ResidualCorrelationImages(ArrayLike):
+
+    def __init__(self,
+                 flyweight: TensorFlyWeight,
+                 fov_dims: tuple[int, int],
+                 mode: ResidCorrMode = ResidCorrMode.DEFAULT):
+        """
+        See from_tensors for parameter documentation
+        """
+
+        self._flyweight = flyweight
+        self._c_norm = self.c - torch.mean(self.c, dim=0, keepdim=True)
+        self._c_norm = self._c_norm / torch.linalg.norm(
+            self._c_norm, dim=0, keepdim=True
+        )
+        self._c_norm = torch.nan_to_num(self._c_norm, nan=0.0)
+        self._fov_dims = (fov_dims[0], fov_dims[1])
+        self._index_values = torch.arange(self._c.shape[1], device=self.device).long()
+
+        self._mode = mode
+
+        self._ones_basis = (
+            torch.ones([1, self._v.shape[1]], device=self.device) @ self._v.T
+        )
+        self._pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
+
+    @classmethod
+    def from_tensors(
+        cls,
         u_sparse: torch.sparse_coo_tensor,
         v: torch.Tensor,
-        factorized_ring_term: Tuple[torch.tensor, torch.tensor],
+        factorized_bkgd_term1: torch.Tensor,
+        factorized_bkgd_term2: torch.Tensor,
         a: torch.sparse_coo_tensor,
         c: torch.Tensor,
         support_correlation_values: torch.sparse_coo_tensor,
         residual_movie_mean: torch.Tensor,
         residual_movie_normalizer: torch.Tensor,
-        fov_dims: Tuple[int, int],
+        fov_dims: tuple[int, int],
         mode: ResidCorrMode = ResidCorrMode.DEFAULT,
     ):
         """
@@ -38,7 +66,8 @@ class ResidualCorrelationImages(FactorizedVideo):
         Args:
             u_sparse (torch.sparse_coo_tensor): shape (pixels, rank 1)
             v (torch.Tensor): shape (rank 2, frames)
-            factorized_ring_term (Tuple[torch.Tensor, torch.Tensor]): A factorized representation of the data background
+            factorized_bkgd_term1 (torch.Tensor):
+            factorized_bkgd_term2 (torch.Tensor):
             a (torch.sparse_coo_tensor): shape (pixels, number of neural signals). Spatial components
             c (torch.tensor): shape (frames, number of neural signals). This is the temporal traces matrix
             support_correlation_values (torch.sparse_coo_tensor): Shape (pixels, number of neural signals). The i-th
@@ -46,48 +75,47 @@ class ResidualCorrelationImages(FactorizedVideo):
             residual_movie_mean (torch.Tensor): shape (pixels)
             residual_movie_normalizer (torch.Tensor): shape (pixels)
             fov_dims (tuple): A tuple of two values describing the field height/width of the field of view.
-            zero_support Optional[bool[: If true, for each neuron, i, the support of neuron i is set to 0 in the i-th
-                correlation image
+            mode (ResidCorrMode): The mode of the residual correlation image
         """
+        flyweight = TensorFlyWeight(u=u_sparse,
+                                    v=v,
+                                    factorized_bkgd_term1=factorized_bkgd_term1,
+                                    factorized_bkgd_term2=factorized_bkgd_term2,
+                                    a=a,
+                                    c=c,
+                                    support_correlation_values=support_correlation_values,
+                                    residual_movie_mean=residual_movie_mean,
+                                    residual_movie_normalizer=residual_movie_normalizer,
+                                    )
 
-        if not (
-            u_sparse.device
-            == v.device
-            == c.device
-            == a.device
-            == factorized_ring_term[0].device
-            == factorized_ring_term[1].device
-            == support_correlation_values.device
-            == residual_movie_mean.device
-            == residual_movie_normalizer.device
-        ):
-            raise ValueError("Not all tensors are on same device")
+        return cls(flyweight,
+                   fov_dims,
+                   mode=mode)
 
-        self._device = u_sparse.device
-        self._u = u_sparse
-        self._v = v
-        self._background_term = factorized_ring_term
-        self._c = c
-        self._c_norm = self._c - torch.mean(self._c, dim=0, keepdim=True)
-        self._c_norm = self._c_norm / torch.linalg.norm(
-            self._c_norm, dim=0, keepdim=True
-        )
-        self._c_norm = torch.nan_to_num(self._c_norm, nan=0.0)
+    @classmethod
+    def from_flyweight(cls,
+                       flyweight: TensorFlyWeight,
+                       fov_dims: tuple[int, int],
+                       mode: ResidCorrMode = ResidCorrMode.DEFAULT):
+        return cls(flyweight,
+                   fov_dims,
+                   mode=mode)
 
-        self._a = a
-        self._residual_movie_mean = residual_movie_mean
-        self._support_correlation_values = support_correlation_values
-        self._residual_movie_normalizer = residual_movie_normalizer
-        self._fov_dims = (fov_dims[0], fov_dims[1])
-        self._index_values = torch.arange(self._c.shape[1], device=self.device).long()
 
-        self._mode = mode
+    @property
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
 
-        self._ones_basis = (
-            torch.ones([1, self._v.shape[1]], device=self.device) @ self._v.T
-        )
-        self.pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
-            self.shape[1], self.shape[2])
+    @property
+    def device(self) -> str:
+        return self.flyweight.device
+
+    def to(self, new_device: str):
+        self.flyweight.to(new_device)
+        self._pixel_mat = self._pixel_mat.to(new_device)
+        self._ones_basis = self._ones_basis.to(new_device)
+        self._c_norm = self._c_norm.to(new_device)
+
     @property
     def mode(self) -> ResidCorrMode:
         """
@@ -111,8 +139,25 @@ class ResidualCorrelationImages(FactorizedVideo):
         return self._device
 
     @property
-    def shape(self) -> Tuple[int, int, int]:
+    def shape(self) -> tuple[int, int, int]:
         return self._c.shape[1], self._fov_dims[0], self._fov_dims[1]
+
+    @property
+    def u(self) -> torch.sparse_coo_tensor:
+        return self.flyweight.u
+
+    @property
+    def v(self) -> torch.Tensor:
+        return self.flyweight.v
+
+
+    @property
+    def a(self) -> torch.sparse_coo_tensor:
+        return self.flyweight.a
+
+    @property
+    def c(self) -> torch.Tensor:
+        return self.flyweight.c
 
     @property
     def support_correlation_values(self) -> torch.sparse_coo_tensor:
@@ -125,6 +170,14 @@ class ResidualCorrelationImages(FactorizedVideo):
     @property
     def residual_movie_normalizer(self) -> torch.Tensor:
         return self._residual_movie_normalizer
+
+    @property
+    def factorized_bkgd_term1(self) -> torch.Tensor:
+        return self.flyweight.factorized_bkgd_term1
+
+    @property
+    def factorized_bkgd_term2(self) -> torch.Tensor:
+        return self.flyweight.factorized_bkgd_term2
 
     @property
     def ndim(self) -> int:
@@ -145,8 +198,8 @@ class ResidualCorrelationImages(FactorizedVideo):
         if c_crop.ndim < self._c_norm.ndim:
             c_crop = c_crop.unsqueeze(1)
 
-        v_crop = self._v @ c_crop - (self._background_term[0] @ (self._background_term[1] @ c_crop))
-        cc_crop = self._c.T @ c_crop
+        v_crop = self.v @ c_crop - (self.factorized_bkgd_term1 @ (self.factorized_bkgd_term2 @ c_crop))
+        cc_crop = self.c.T @ c_crop
         selected_neurons = self._index_values[frame_indexer]
         if selected_neurons.ndim < 1:
             selected_neurons = selected_neurons.unsqueeze(0)
@@ -158,23 +211,23 @@ class ResidualCorrelationImages(FactorizedVideo):
         if isinstance(item, tuple) and check_spatial_crop_effect(
             item[1:], self.shape[1:]
         ):
-            pixel_space_crop = self.pixel_mat[item[1:]]
+            pixel_space_crop = self._pixel_mat[item[1:]]
             u_indices = pixel_space_crop.flatten()
-            u_crop = torch.index_select(self._u, 0, u_indices)
-            a_crop = torch.index_select(self._a, 0, u_indices)
+            u_crop = torch.index_select(self.u, 0, u_indices)
+            a_crop = torch.index_select(self.a, 0, u_indices)
             support_values_crop = torch.index_select(
                 support_values_crop, 0, u_indices
             ).coalesce()
-            mean_crop = torch.index_select(self._residual_movie_mean, 0, u_indices)
+            mean_crop = torch.index_select(self.residual_movie_mean, 0, u_indices)
             movie_normalizer_crop = torch.index_select(
-                self._residual_movie_normalizer, 0, u_indices
+                self.residual_movie_normalizer, 0, u_indices
             )
             implied_fov = pixel_space_crop.shape
         else:
-            u_crop = self._u
-            a_crop = self._a
-            mean_crop = self._residual_movie_mean
-            movie_normalizer_crop = self._residual_movie_normalizer
+            u_crop = self.u
+            a_crop = self.a
+            mean_crop = self.residual_movie_mean
+            movie_normalizer_crop = self.residual_movie_normalizer
             implied_fov = self.shape[1], self.shape[2]
 
         # Temporal term is guaranteed to have nonzero "T" dimension below

--- a/masknmf/demixing/demixing_arrays/residual_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/residual_correlation_images.py
@@ -24,7 +24,6 @@ class ResidualCorrelationImages(FactorizedVideo):
         residual_movie_normalizer: torch.tensor,
         fov_dims: Tuple[int, int],
         mode: ResidCorrMode = ResidCorrMode.DEFAULT,
-        order: str = "F",
     ):
         """
         Array interface for interacting with the residual correlation image data. Data is kept in a memory
@@ -81,19 +80,14 @@ class ResidualCorrelationImages(FactorizedVideo):
         self._residual_movie_normalizer = residual_movie_normalizer
         self._fov_dims = (fov_dims[0], fov_dims[1])
         self._index_values = torch.arange(self._c.shape[1], device=self.device).long()
-        self._order = order
 
         self._mode = mode
 
         self._ones_basis = (
             torch.ones([1, self._v.shape[1]], device=self.device) @ self._v.T
         )
-
-        self.pixel_mat = np.arange(np.prod(self.shape[1:])).reshape(
-            [self.shape[1], self.shape[2]], order=order
-        )
-        self.pixel_mat = torch.from_numpy(self.pixel_mat).long().to(self.device)
-
+        self.pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
     @property
     def mode(self) -> ResidCorrMode:
         """
@@ -125,16 +119,12 @@ class ResidualCorrelationImages(FactorizedVideo):
         return self._support_correlation_values
 
     @property
-    def residual_movie_mean(self) -> torch.tensor:
+    def residual_movie_mean(self) -> torch.Tensor:
         return self._residual_movie_mean
 
     @property
-    def residual_movie_normalizer(self) -> torch.tensor:
+    def residual_movie_normalizer(self) -> torch.Tensor:
         return self._residual_movie_normalizer
-
-    @property
-    def order(self) -> str:
-        return self._order
 
     @property
     def ndim(self) -> int:
@@ -147,7 +137,7 @@ class ResidualCorrelationImages(FactorizedVideo):
     def getitem_tensor(
         self,
         item: Union[int, list, np.ndarray, Tuple[Union[int, np.ndarray, slice, range]]],
-    ) -> torch.tensor:
+    ) -> torch.Tensor:
         frame_indexer, item = self._parse_indices(item)
 
         # Step 3: Now slice the data with frame_indexer (careful: if the ndims has shrunk, add a dim)
@@ -180,14 +170,12 @@ class ResidualCorrelationImages(FactorizedVideo):
                 self._residual_movie_normalizer, 0, u_indices
             )
             implied_fov = pixel_space_crop.shape
-            used_order = "C"  # The crop from pixel mat and flattening means we are now using default torch order
         else:
             u_crop = self._u
             a_crop = self._a
             mean_crop = self._residual_movie_mean
             movie_normalizer_crop = self._residual_movie_normalizer
             implied_fov = self.shape[1], self.shape[2]
-            used_order = self.order
 
         # Temporal term is guaranteed to have nonzero "T" dimension below
         ## TODO: If you only had 2 matrices in the factorization, this if/else is useless. But eventually background term will be its own factorization. So keep this for now.
@@ -213,12 +201,8 @@ class ResidualCorrelationImages(FactorizedVideo):
         elif self.mode == ResidCorrMode.RESIDUAL:
             pass
 
-        if used_order == "F":
-            product = product.T.reshape((-1, implied_fov[1], implied_fov[0]))
-            product = product.permute((0, 2, 1))
-        else:  # order is "C"
-            product = product.reshape((implied_fov[0], implied_fov[1], -1))
-            product = product.permute(2, 0, 1)
+        product = product.reshape((implied_fov[0], implied_fov[1], -1))
+        product = product.permute(2, 0, 1)
 
         return torch.nan_to_num(product, nan=0.0, posinf=0.0, neginf=0.0)
 

--- a/masknmf/demixing/demixing_arrays/residual_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/residual_correlation_images.py
@@ -22,20 +22,29 @@ class ResidualCorrelationImages(ArrayLike):
         """
 
         self._flyweight = flyweight
+        self.flyweight.validate_attributes(["u",
+                                            "v",
+                                            "factorized_bkgd_term1",
+                                            "factorized_bkgd_term2",
+                                            "a",
+                                            "c",
+                                            "support_correlation_values",
+                                            "residual_movie_mean",
+                                            "residual_movie_normalizer"])
         self._c_norm = self.c - torch.mean(self.c, dim=0, keepdim=True)
         self._c_norm = self._c_norm / torch.linalg.norm(
             self._c_norm, dim=0, keepdim=True
         )
         self._c_norm = torch.nan_to_num(self._c_norm, nan=0.0)
         self._fov_dims = (fov_dims[0], fov_dims[1])
-        self._index_values = torch.arange(self._c.shape[1], device=self.device).long()
+        self._index_values = torch.arange(self.c.shape[1], device=self.device).long()
 
         self._mode = mode
 
         self._ones_basis = (
-            torch.ones([1, self._v.shape[1]], device=self.device) @ self._v.T
+            torch.ones([1, self.v.shape[1]], device=self.device) @ self.v.T
         )
-        self._pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+        self._pixel_mat = torch.arange(self.shape[1] * self.shape[2], device=self.device, dtype=torch.long).reshape(
             self.shape[1], self.shape[2])
 
     @classmethod
@@ -111,7 +120,12 @@ class ResidualCorrelationImages(ArrayLike):
         return self.flyweight.device
 
     def to(self, new_device: str):
-        self.flyweight.to(new_device)
+        if self._flyweight.device != new_device:
+            self._flyweight.to(new_device)
+        self._move_local_tensors(new_device)
+
+    def _move_local_tensors(self, new_device: str):
+        self._index_values = self._index_values.to(new_device)
         self._pixel_mat = self._pixel_mat.to(new_device)
         self._ones_basis = self._ones_basis.to(new_device)
         self._c_norm = self._c_norm.to(new_device)
@@ -136,11 +150,11 @@ class ResidualCorrelationImages(ArrayLike):
         """
         This specifies what device the internal tensors used for the lazy computations are located.
         """
-        return self._device
+        return self.flyweight.device
 
     @property
     def shape(self) -> tuple[int, int, int]:
-        return self._c.shape[1], self._fov_dims[0], self._fov_dims[1]
+        return self.c.shape[1], self._fov_dims[0], self._fov_dims[1]
 
     @property
     def u(self) -> torch.sparse_coo_tensor:
@@ -161,15 +175,15 @@ class ResidualCorrelationImages(ArrayLike):
 
     @property
     def support_correlation_values(self) -> torch.sparse_coo_tensor:
-        return self._support_correlation_values
+        return self.flyweight.support_correlation_values
 
     @property
     def residual_movie_mean(self) -> torch.Tensor:
-        return self._residual_movie_mean
+        return self.flyweight.residual_movie_mean
 
     @property
     def residual_movie_normalizer(self) -> torch.Tensor:
-        return self._residual_movie_normalizer
+        return self.flyweight.residual_movie_normalizer
 
     @property
     def factorized_bkgd_term1(self) -> torch.Tensor:
@@ -204,7 +218,7 @@ class ResidualCorrelationImages(ArrayLike):
         if selected_neurons.ndim < 1:
             selected_neurons = selected_neurons.unsqueeze(0)
         support_values_crop = torch.index_select(
-            self._support_correlation_values, 1, selected_neurons
+            self.support_correlation_values, 1, selected_neurons
         ).coalesce()
 
         # Step 4: Deal with remaining indices after lazy computing the frame(s)

--- a/masknmf/demixing/demixing_arrays/residual_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/residual_correlation_images.py
@@ -15,13 +15,13 @@ class ResidualCorrelationImages(FactorizedVideo):
     def __init__(
         self,
         u_sparse: torch.sparse_coo_tensor,
-        v: torch.tensor,
+        v: torch.Tensor,
         factorized_ring_term: Tuple[torch.tensor, torch.tensor],
         a: torch.sparse_coo_tensor,
-        c: torch.tensor,
+        c: torch.Tensor,
         support_correlation_values: torch.sparse_coo_tensor,
-        residual_movie_mean: torch.tensor,
-        residual_movie_normalizer: torch.tensor,
+        residual_movie_mean: torch.Tensor,
+        residual_movie_normalizer: torch.Tensor,
         fov_dims: Tuple[int, int],
         mode: ResidCorrMode = ResidCorrMode.DEFAULT,
     ):
@@ -37,14 +37,14 @@ class ResidualCorrelationImages(FactorizedVideo):
 
         Args:
             u_sparse (torch.sparse_coo_tensor): shape (pixels, rank 1)
-            v (torch.tensor): shape (rank 2, frames)
-            factorized_ring_term (Tuple[torch.tensor, torch.tensor]): A factorized representation of the data background
+            v (torch.Tensor): shape (rank 2, frames)
+            factorized_ring_term (Tuple[torch.Tensor, torch.Tensor]): A factorized representation of the data background
             a (torch.sparse_coo_tensor): shape (pixels, number of neural signals). Spatial components
             c (torch.tensor): shape (frames, number of neural signals). This is the temporal traces matrix
             support_correlation_values (torch.sparse_coo_tensor): Shape (pixels, number of neural signals). The i-th
                 gives the residual correlation image for neural signal "i" on its spatial support.
-            residual_movie_mean (torch.tensor): shape (pixels)
-            residual_movie_normalizer (torch.tensor): shape (pixels)
+            residual_movie_mean (torch.Tensor): shape (pixels)
+            residual_movie_normalizer (torch.Tensor): shape (pixels)
             fov_dims (tuple): A tuple of two values describing the field height/width of the field of view.
             zero_support Optional[bool[: If true, for each neuron, i, the support of neuron i is set to 0 in the i-th
                 correlation image

--- a/masknmf/demixing/demixing_arrays/residual_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/residual_correlation_images.py
@@ -28,9 +28,9 @@ class ResidualCorrelationImages(ArrayLike):
                                             "factorized_bkgd_term2",
                                             "a",
                                             "c",
-                                            "support_correlation_values",
-                                            "residual_movie_mean",
-                                            "residual_movie_normalizer"])
+                                            "resid_corr_img_support_values",
+                                            "resid_corr_img_mean",
+                                            "resid_corr_img_normalizer"])
         self._c_norm = self.c - torch.mean(self.c, dim=0, keepdim=True)
         self._c_norm = self._c_norm / torch.linalg.norm(
             self._c_norm, dim=0, keepdim=True
@@ -56,9 +56,9 @@ class ResidualCorrelationImages(ArrayLike):
         factorized_bkgd_term2: torch.Tensor,
         a: torch.sparse_coo_tensor,
         c: torch.Tensor,
-        support_correlation_values: torch.sparse_coo_tensor,
-        residual_movie_mean: torch.Tensor,
-        residual_movie_normalizer: torch.Tensor,
+        resid_corr_img_support_values: torch.sparse_coo_tensor,
+        resid_corr_img_mean: torch.Tensor,
+        resid_corr_img_normalizer: torch.Tensor,
         fov_dims: tuple[int, int],
         mode: ResidCorrMode = ResidCorrMode.DEFAULT,
     ):
@@ -79,10 +79,10 @@ class ResidualCorrelationImages(ArrayLike):
             factorized_bkgd_term2 (torch.Tensor):
             a (torch.sparse_coo_tensor): shape (pixels, number of neural signals). Spatial components
             c (torch.tensor): shape (frames, number of neural signals). This is the temporal traces matrix
-            support_correlation_values (torch.sparse_coo_tensor): Shape (pixels, number of neural signals). The i-th
+            resid_corr_img_support_values (torch.sparse_coo_tensor): Shape (pixels, number of neural signals). The i-th
                 gives the residual correlation image for neural signal "i" on its spatial support.
-            residual_movie_mean (torch.Tensor): shape (pixels)
-            residual_movie_normalizer (torch.Tensor): shape (pixels)
+            resid_corr_img_mean (torch.Tensor): shape (pixels)
+            resid_corr_img_normalizer (torch.Tensor): shape (pixels)
             fov_dims (tuple): A tuple of two values describing the field height/width of the field of view.
             mode (ResidCorrMode): The mode of the residual correlation image
         """
@@ -92,9 +92,9 @@ class ResidualCorrelationImages(ArrayLike):
                                     factorized_bkgd_term2=factorized_bkgd_term2,
                                     a=a,
                                     c=c,
-                                    support_correlation_values=support_correlation_values,
-                                    residual_movie_mean=residual_movie_mean,
-                                    residual_movie_normalizer=residual_movie_normalizer,
+                                    resid_corr_img_support_values=resid_corr_img_support_values,
+                                    resid_corr_img_mean=resid_corr_img_mean,
+                                    resid_corr_img_normalizer=resid_corr_img_normalizer,
                                     )
 
         return cls(flyweight,
@@ -174,16 +174,16 @@ class ResidualCorrelationImages(ArrayLike):
         return self.flyweight.c
 
     @property
-    def support_correlation_values(self) -> torch.sparse_coo_tensor:
-        return self.flyweight.support_correlation_values
+    def resid_corr_img_support_values(self) -> torch.sparse_coo_tensor:
+        return self.flyweight.resid_corr_img_support_values
 
     @property
-    def residual_movie_mean(self) -> torch.Tensor:
-        return self.flyweight.residual_movie_mean
+    def resid_corr_img_mean(self) -> torch.Tensor:
+        return self.flyweight.resid_corr_img_mean
 
     @property
-    def residual_movie_normalizer(self) -> torch.Tensor:
-        return self.flyweight.residual_movie_normalizer
+    def resid_corr_img_normalizer(self) -> torch.Tensor:
+        return self.flyweight.resid_corr_img_normalizer
 
     @property
     def factorized_bkgd_term1(self) -> torch.Tensor:
@@ -218,7 +218,7 @@ class ResidualCorrelationImages(ArrayLike):
         if selected_neurons.ndim < 1:
             selected_neurons = selected_neurons.unsqueeze(0)
         support_values_crop = torch.index_select(
-            self.support_correlation_values, 1, selected_neurons
+            self.resid_corr_img_support_values, 1, selected_neurons
         ).coalesce()
 
         # Step 4: Deal with remaining indices after lazy computing the frame(s)
@@ -232,16 +232,16 @@ class ResidualCorrelationImages(ArrayLike):
             support_values_crop = torch.index_select(
                 support_values_crop, 0, u_indices
             ).coalesce()
-            mean_crop = torch.index_select(self.residual_movie_mean, 0, u_indices)
+            mean_crop = torch.index_select(self.resid_corr_img_mean, 0, u_indices)
             movie_normalizer_crop = torch.index_select(
-                self.residual_movie_normalizer, 0, u_indices
+                self.resid_corr_img_normalizer, 0, u_indices
             )
             implied_fov = pixel_space_crop.shape
         else:
             u_crop = self.u
             a_crop = self.a
-            mean_crop = self.residual_movie_mean
-            movie_normalizer_crop = self.residual_movie_normalizer
+            mean_crop = self.resid_corr_img_mean
+            movie_normalizer_crop = self.resid_corr_img_normalizer
             implied_fov = self.shape[1], self.shape[2]
 
         # Temporal term is guaranteed to have nonzero "T" dimension below

--- a/masknmf/demixing/demixing_arrays/standard_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/standard_correlation_images.py
@@ -61,7 +61,7 @@ class StandardCorrelationImages(ArrayLike):
                                     v=v,
                                     c=c,
                                     std_corr_img_mean=std_corr_img_mean,
-                                    movie_normalizer=std_corr_img_normalizer)
+                                    std_corr_img_normalizer=std_corr_img_normalizer)
         return cls(flyweight,
                    fov_dims)
 

--- a/masknmf/demixing/demixing_arrays/standard_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/standard_correlation_images.py
@@ -17,12 +17,16 @@ class StandardCorrelationImages(ArrayLike):
         """
 
         self._flyweight = flyweight
-        self.flyweight.validate_attributes(['u', 'v', 'c', 'movie_mean', 'movie_normalizer'])
+        self.flyweight.validate_attributes(['u',
+                                            'v',
+                                            'c',
+                                            'movie_mean',
+                                            'movie_normalizer'])
 
         ## Caution: This tensor is "settable" (when you update self._c the correlation image dynamically changes). So the getter for c should just call flyweight.c
         self._c = None
         self.c = flyweight.c
-        self._pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+        self._pixel_mat = torch.arange(self.shape[1]*self.shape[2], device=self.device, dtype=torch.long).reshape(
             self.shape[1], self.shape[2])
         self._fov_dims = fov_dims
         self._ones_frames = torch.ones(
@@ -81,7 +85,11 @@ class StandardCorrelationImages(ArrayLike):
         return self._flyweight.device
 
     def to(self, new_device: str):
-        self.flyweight.to(new_device)
+        if self._flyweight.device != new_device:
+            self._flyweight.to(new_device)
+        self._move_local_tensors(new_device)
+
+    def _move_local_tensors(self, new_device: str):
         self._ones_frames = self._ones_frames.to(new_device)
         self._pixel_mat = self._pixel_mat.to(new_device)
         self._c = self._c.to(new_device)

--- a/masknmf/demixing/demixing_arrays/standard_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/standard_correlation_images.py
@@ -107,7 +107,7 @@ class StandardCorrelationImages(ArrayLike):
         self._c = mean_zero
 
     @property
-    def u(self) -> torch.sprase_coo_tensor:
+    def u(self) -> torch.sparse_coo_tensor:
         return self.flyweight.u
 
     @property

--- a/masknmf/demixing/demixing_arrays/standard_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/standard_correlation_images.py
@@ -1,13 +1,39 @@
 from typing import *
 import numpy as np
-from masknmf.arrays.array_interfaces import FactorizedVideo
+
+from masknmf import TensorFlyWeight
+from masknmf.arrays.array_interfaces import ArrayLike, TensorFlyWeight
 import torch
 from masknmf.demixing.demixing_arrays.demixing_array_utils import check_spatial_crop_effect
 
 
-class StandardCorrelationImages(FactorizedVideo):
-    def __init__(
-        self,
+class StandardCorrelationImages(ArrayLike):
+
+    def __init__(self,
+                 flyweight: TensorFlyWeight,
+                 fov_dims: tuple[int, int]):
+        """
+        see from_tensor docs for detailed parameter information
+        """
+
+        self._flyweight = flyweight
+        self.flyweight.validate_attributes(['u', 'v', 'c', 'movie_mean', 'movie_normalizer'])
+
+        ## Caution: This tensor is "settable" (when you update self._c the correlation image dynamically changes). So the getter for c should just call flyweight.c
+        self._c = None
+        self.c = flyweight.c
+        self._pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
+        self._fov_dims = fov_dims
+        self._ones_frames = torch.ones(
+            (1, self.v.shape[1]), device=self.device, dtype=torch.float
+        )
+
+
+
+    @classmethod
+    def from_tensors(
+        cls,
         u_sparse: torch.sparse_coo_tensor,
         v: torch.Tensor,
         c: torch.Tensor,
@@ -26,42 +52,47 @@ class StandardCorrelationImages(FactorizedVideo):
                 column has mean 0 and Frobenius norm 1.
             movie_mean (torch.tensor): shape (pixels), the mean of u_sparse times v
             movie_normalizer (torch.Tensor): shape (pixels), the pixelwise l2 norm of (u_sparse times v) - movie_mean
+            fov_dims (tuple[int, int]): A (height, width) tuple describing field of view (fov) dimensions
         """
+        flyweight = TensorFlyWeight(u=u_sparse,
+                                    v=v,
+                                    c=c,
+                                    movie_mean=movie_mean,
+                                    movie_normalizer=movie_normalizer)
+        return cls(flyweight,
+                   fov_dims)
 
-        if not (u_sparse.device == v.device == c.device):
-            raise ValueError("Not all tensors are on same device")
+    @classmethod
+    def from_flyweight(cls,
+                       flyweight: TensorFlyWeight,
+                       fov_dims: tuple[int, int]):
+        return cls(flyweight,
+            fov_dims)
 
-        self._device = u_sparse.device
-        self._u = u_sparse
-        self._v = v
-        self._c = None
-        self.c = c # All temporal data goes through the setter to get normalized
-        self._movie_mean = movie_mean
-        self._movie_normalizer = movie_normalizer
-        self._fov_dims = (fov_dims[0], fov_dims[1])
-
-        self.pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
-            self.shape[1], self.shape[2])
-
-        self._ones_frames = torch.ones(
-            (1, self._v.shape[1]), device=self.device, dtype=torch.float
-        )
-
+    @property
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
 
     @property
     def device(self) -> str:
         """
         This specifies what device the internal tensors used for the lazy computations are located.
         """
-        return self._device
+        return self._flyweight.device
+
+    def to(self, new_device: str):
+        self.flyweight.to(new_device)
+        self._ones_frames = self._ones_frames.to(new_device)
+        self._pixel_mat = self._pixel_mat.to(new_device)
+        self._c = self._c.to(new_device)
 
     @property
-    def c(self) -> torch.tensor:
+    def c(self) -> torch.Tensor:
         return self._c
 
     @c.setter
-    def c(self, new_tensor):
-        if new_tensor.shape[0] != self._v.shape[1]:
+    def c(self, new_tensor: torch.Tensor):
+        if new_tensor.shape[0] != self.v.shape[1]:
             raise ValueError(
                 f"Input temporal trace matrix has {new_tensor.shape[0]} frames"
                 f"which is incompatible with the movie, which has {self._v.shape[1]} frames"
@@ -72,16 +103,26 @@ class StandardCorrelationImages(FactorizedVideo):
         self._c = mean_zero
 
     @property
-    def shape(self) -> Tuple[int, int, int]:
-        return self.c.shape[1], self._fov_dims[0], self._fov_dims[1]
+    def u(self) -> torch.sprase_coo_tensor:
+        return self.flyweight.u
+
+    @property
+    def v(self) -> torch.Tensor:
+        return self.flyweight.v
+
 
     @property
     def movie_mean(self) -> torch.Tensor:
-        return self._movie_mean
+        return self.flyweight.movie_mean
 
     @property
     def movie_normalizer(self) -> torch.Tensor:
-        return self._movie_normalizer
+        return self.flyweight.movie_normalizer
+
+    @property
+    def shape(self) -> Tuple[int, int, int]:
+        return self.c.shape[1], self._fov_dims[0], self._fov_dims[1]
+
 
     @property
     def ndim(self) -> int:
@@ -102,25 +143,25 @@ class StandardCorrelationImages(FactorizedVideo):
         if c_crop.ndim < self._c.ndim:
             c_crop = c_crop.unsqueeze(1)
 
-        v_crop = self._v @ c_crop
+        v_crop = self.v @ c_crop
         ones_crop = self._ones_frames @ c_crop
 
         # Step 4: Deal with remaining indices after lazy computing the frame(s)
         if isinstance(item, tuple) and check_spatial_crop_effect(
             item[1:], self.shape[1:]
         ):
-            pixel_space_crop = self.pixel_mat[item[1:]]
+            pixel_space_crop = self._pixel_mat[item[1:]]
             u_indices = pixel_space_crop.flatten()
-            u_crop = torch.index_select(self._u, 0, u_indices)
-            mean_crop = torch.index_select(self._movie_mean, 0, u_indices)
+            u_crop = torch.index_select(self.u, 0, u_indices)
+            mean_crop = torch.index_select(self.movie_mean, 0, u_indices)
             movie_normalizer_crop = torch.index_select(
-                self._movie_normalizer, 0, u_indices
+                self.movie_normalizer, 0, u_indices
             )
             implied_fov = pixel_space_crop.shape
         else:
-            u_crop = self._u
-            mean_crop = self._movie_mean
-            movie_normalizer_crop = self._movie_normalizer
+            u_crop = self.u
+            mean_crop = self.movie_mean
+            movie_normalizer_crop = self.movie_normalizer
             implied_fov = self.shape[1], self.shape[2]
 
         product = (

--- a/masknmf/demixing/demixing_arrays/standard_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/standard_correlation_images.py
@@ -15,20 +15,19 @@ class StandardCorrelationImages(ArrayLike):
         """
         see from_tensor docs for detailed parameter information
         """
-
+        self._fov_dims = fov_dims
         self._flyweight = flyweight
         self.flyweight.validate_attributes(['u',
                                             'v',
                                             'c',
-                                            'movie_mean',
-                                            'movie_normalizer'])
+                                            'std_corr_img_mean',
+                                            'std_corr_img_normalizer'])
 
         ## Caution: This tensor is "settable" (when you update self._c the correlation image dynamically changes). So the getter for c should just call flyweight.c
         self._c = None
         self.c = flyweight.c
         self._pixel_mat = torch.arange(self.shape[1]*self.shape[2], device=self.device, dtype=torch.long).reshape(
             self.shape[1], self.shape[2])
-        self._fov_dims = fov_dims
         self._ones_frames = torch.ones(
             (1, self.v.shape[1]), device=self.device, dtype=torch.float
         )
@@ -41,8 +40,8 @@ class StandardCorrelationImages(ArrayLike):
         u_sparse: torch.sparse_coo_tensor,
         v: torch.Tensor,
         c: torch.Tensor,
-        movie_mean: torch.Tensor,
-        movie_normalizer: torch.Tensor,
+        std_corr_img_mean: torch.Tensor,
+        std_corr_img_normalizer: torch.Tensor,
         fov_dims: Tuple[int, int],
     ):
         """
@@ -54,15 +53,15 @@ class StandardCorrelationImages(ArrayLike):
             v (torch.Tensor): shape (rank, frames)
             c (torch.Tensor): shape (frames, number of neural signals). This is the temporal traces matrix, where every
                 column has mean 0 and Frobenius norm 1.
-            movie_mean (torch.tensor): shape (pixels), the mean of u_sparse times v
-            movie_normalizer (torch.Tensor): shape (pixels), the pixelwise l2 norm of (u_sparse times v) - movie_mean
+            std_corr_img_mean (torch.Tensor): shape (pixels), the mean of u_sparse times v
+            std_corr_img_normalizer (torch.Tensor): shape (pixels), the pixelwise l2 norm of (u_sparse times v) - movie_mean
             fov_dims (tuple[int, int]): A (height, width) tuple describing field of view (fov) dimensions
         """
         flyweight = TensorFlyWeight(u=u_sparse,
                                     v=v,
                                     c=c,
-                                    movie_mean=movie_mean,
-                                    movie_normalizer=movie_normalizer)
+                                    std_corr_img_mean=std_corr_img_mean,
+                                    movie_normalizer=std_corr_img_normalizer)
         return cls(flyweight,
                    fov_dims)
 
@@ -124,12 +123,12 @@ class StandardCorrelationImages(ArrayLike):
 
 
     @property
-    def movie_mean(self) -> torch.Tensor:
-        return self.flyweight.movie_mean
+    def std_corr_img_mean(self) -> torch.Tensor:
+        return self.flyweight.std_corr_img_mean
 
     @property
-    def movie_normalizer(self) -> torch.Tensor:
-        return self.flyweight.movie_normalizer
+    def std_corr_img_normalizer(self) -> torch.Tensor:
+        return self.flyweight.std_corr_img_normalizer
 
     @property
     def shape(self) -> Tuple[int, int, int]:
@@ -165,15 +164,15 @@ class StandardCorrelationImages(ArrayLike):
             pixel_space_crop = self._pixel_mat[item[1:]]
             u_indices = pixel_space_crop.flatten()
             u_crop = torch.index_select(self.u, 0, u_indices)
-            mean_crop = torch.index_select(self.movie_mean, 0, u_indices)
+            mean_crop = torch.index_select(self.std_corr_img_mean, 0, u_indices)
             movie_normalizer_crop = torch.index_select(
-                self.movie_normalizer, 0, u_indices
+                self.std_corr_img_normalizer, 0, u_indices
             )
             implied_fov = pixel_space_crop.shape
         else:
             u_crop = self.u
-            mean_crop = self.movie_mean
-            movie_normalizer_crop = self.movie_normalizer
+            mean_crop = self.std_corr_img_mean
+            movie_normalizer_crop = self.std_corr_img_normalizer
             implied_fov = self.shape[1], self.shape[2]
 
         product = (

--- a/masknmf/demixing/demixing_arrays/standard_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/standard_correlation_images.py
@@ -9,12 +9,11 @@ class StandardCorrelationImages(FactorizedVideo):
     def __init__(
         self,
         u_sparse: torch.sparse_coo_tensor,
-        v: torch.tensor,
-        c: torch.tensor,
-        movie_mean: torch.tensor,
-        movie_normalizer: torch.tensor,
+        v: torch.Tensor,
+        c: torch.Tensor,
+        movie_mean: torch.Tensor,
+        movie_normalizer: torch.Tensor,
         fov_dims: Tuple[int, int],
-        order: str = "F",
     ):
         """
         Generates all the standard correlation images for the demixed data. It is more convenient to keep the
@@ -22,11 +21,11 @@ class StandardCorrelationImages(FactorizedVideo):
 
         Args:
             u_sparse (torch.sparse_coo_tensor): shape (pixels, rank)
-            v (torch.tensor): shape (rank, frames)
-            c (torch.tensor): shape (frames, number of neural signals). This is the temporal traces matrix, where every
+            v (torch.Tensor): shape (rank, frames)
+            c (torch.Tensor): shape (frames, number of neural signals). This is the temporal traces matrix, where every
                 column has mean 0 and Frobenius norm 1.
             movie_mean (torch.tensor): shape (pixels), the mean of u_sparse times v
-            movie_normalizer (torch.tensor): shape (pixels), the pixelwise l2 norm of (u_sparse times v) - movie_mean
+            movie_normalizer (torch.Tensor): shape (pixels), the pixelwise l2 norm of (u_sparse times v) - movie_mean
         """
 
         if not (u_sparse.device == v.device == c.device):
@@ -40,17 +39,14 @@ class StandardCorrelationImages(FactorizedVideo):
         self._movie_mean = movie_mean
         self._movie_normalizer = movie_normalizer
         self._fov_dims = (fov_dims[0], fov_dims[1])
-        self._order = order
 
-        self.pixel_mat = np.arange(np.prod(self.shape[1:])).reshape(
-            [self.shape[1], self.shape[2]], order=order
-        )
+        self.pixel_mat = torch.arange(np.prod(self.shape[1:3]), device=self.device, dtype=torch.long).reshape(
+            self.shape[1], self.shape[2])
 
         self._ones_frames = torch.ones(
             (1, self._v.shape[1]), device=self.device, dtype=torch.float
         )
 
-        self.pixel_mat = torch.from_numpy(self.pixel_mat).long().to(self.device)
 
     @property
     def device(self) -> str:
@@ -80,16 +76,12 @@ class StandardCorrelationImages(FactorizedVideo):
         return self.c.shape[1], self._fov_dims[0], self._fov_dims[1]
 
     @property
-    def movie_mean(self) -> torch.tensor:
+    def movie_mean(self) -> torch.Tensor:
         return self._movie_mean
 
     @property
-    def movie_normalizer(self) -> torch.tensor:
+    def movie_normalizer(self) -> torch.Tensor:
         return self._movie_normalizer
-
-    @property
-    def order(self) -> str:
-        return self._order
 
     @property
     def ndim(self) -> int:
@@ -125,24 +117,19 @@ class StandardCorrelationImages(FactorizedVideo):
                 self._movie_normalizer, 0, u_indices
             )
             implied_fov = pixel_space_crop.shape
-            used_order = "C"  # The crop from pixel mat and flattening means we are now using default torch order
         else:
             u_crop = self._u
             mean_crop = self._movie_mean
             movie_normalizer_crop = self._movie_normalizer
             implied_fov = self.shape[1], self.shape[2]
-            used_order = self.order
 
         product = (
             torch.sparse.mm(u_crop, v_crop) - mean_crop.unsqueeze(1) @ ones_crop
         ) / movie_normalizer_crop.unsqueeze(1)
 
-        if used_order == "F":
-            product = product.T.reshape((-1, implied_fov[1], implied_fov[0]))
-            product = product.permute((0, 2, 1))
-        else:  # order is "C"
-            product = product.reshape((implied_fov[0], implied_fov[1], -1))
-            product = product.permute(2, 0, 1)
+
+        product = product.reshape((implied_fov[0], implied_fov[1], -1))
+        product = product.permute(2, 0, 1)
 
         return torch.nan_to_num(product, nan=0.0, posinf=0.0, neginf=0.0)
 

--- a/masknmf/demixing/demixing_arrays/standard_correlation_images.py
+++ b/masknmf/demixing/demixing_arrays/standard_correlation_images.py
@@ -88,6 +88,10 @@ class StandardCorrelationImages(ArrayLike):
 
     @property
     def c(self) -> torch.Tensor:
+        """
+        Because this tensor is settable, we do not want to default to the flyweight (in other words,
+        this attribute is an 'extrinsic' property that is not really shared
+        """
         return self._c
 
     @c.setter

--- a/masknmf/demixing/demixing_arrays/static_baseline.py
+++ b/masknmf/demixing/demixing_arrays/static_baseline.py
@@ -1,0 +1,97 @@
+from typing import *
+import numpy as np
+from masknmf.arrays.array_interfaces import ArrayLike, TensorFlyWeight
+import torch
+from masknmf.demixing.demixing_arrays.demixing_array_utils import check_spatial_crop_effect
+
+class StaticBackgroundArray(ArrayLike):
+    """
+    Class for managing static baseline estimates. These are typically 2D tensors, shape (height, width)
+    """
+
+    def __init__(
+            self,
+            flyweight: TensorFlyWeight,
+            rescale: bool = False,
+    ):
+        self._flyweight=flyweight
+        self._shape = self.flyweight.baseline.shape
+        self._rescale=rescale
+
+    @property
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
+
+    @classmethod
+    def from_tensors(cls,
+                     baseline: torch.Tensor,
+                     normalizer: Optional[torch.Tensor] = None):
+        """
+        Constructor for static baseline class
+        Args:
+            baseline (torch.Tensor): Shape (height, width)
+            normalizer (Optional[torch.Tensor]): Shape (height, width)
+        """
+
+        flyweight = TensorFlyWeight(baseline=baseline, normalizer=normalizer)
+        return cls(flyweight,
+                   rescale=rescale)
+
+    @classmethod
+    def from_flyweight(cls,
+                       flyweight: TensorFlyWeight,
+                       rescale: bool = False):
+        return cls(flyweight,
+                   rescale=rescale)
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self._shape
+
+    @property
+    def dtype(self) -> str:
+        """
+        data type, default np.float32
+        """
+        return np.float32
+
+    @property
+    def normalizer(self) -> torch.Tensor:
+        if not hasattr(self.flyweight, "normalizer"):
+            return self._default_normalizer
+
+    @property
+    def rescale(self):
+        return self._rescale
+
+    @rescale.setter
+    def rescale(self, new_value: bool):
+        self._rescale = new_value
+
+    @property
+    def baseline(self) -> torch.Tensor:
+        return self.flyweight.baseline
+
+    def getitem_tensor(
+            self,
+            item: Union[int, list, np.ndarray, Tuple[Union[int, np.ndarray, slice, range]]],
+    ):
+        cropped_baseline = self.baseline[item]
+        if self.rescale:
+            cropped_normalizer = self.normalizer[item]
+            cropped_baseline *= cropped_normalize
+
+        return cropped_baseline
+
+    def __getitem__(
+        self,
+        item: Union[int, list, np.ndarray, Tuple[Union[int, np.ndarray, slice, range]]],
+    ) -> np.ndarray:
+        product = self.getitem_tensor(item)
+        product = product.cpu().numpy().astype(self.dtype)
+        return product
+
+
+
+
+

--- a/masknmf/demixing/demixing_arrays/static_baseline.py
+++ b/masknmf/demixing/demixing_arrays/static_baseline.py
@@ -15,8 +15,15 @@ class StaticBackgroundArray(ArrayLike):
             rescale: bool = False,
     ):
         self._flyweight=flyweight
+        self.flyweight.validate_attributes(["baseline"])
         self._shape = self.flyweight.baseline.shape
         self._rescale=rescale
+
+        self._default_normalizer = torch.ones_like(self.baseline, device=self.device).float()
+        if hasattr(self.flyweight, "normalizer"):
+            if self.flyweight.normalizer.shape[0] != self.shape[0] or self.flyweight.normalizer.shape[1] != self.shape[
+                1]:
+                raise ValueError("Normalizer from flyweight had dimensions not equal to the fov dimensions")
 
     @property
     def flyweight(self) -> TensorFlyWeight:
@@ -25,7 +32,8 @@ class StaticBackgroundArray(ArrayLike):
     @classmethod
     def from_tensors(cls,
                      baseline: torch.Tensor,
-                     normalizer: Optional[torch.Tensor] = None):
+                     normalizer: Optional[torch.Tensor] = None,
+                     rescale: bool=False):
         """
         Constructor for static baseline class
         Args:
@@ -45,6 +53,19 @@ class StaticBackgroundArray(ArrayLike):
                    rescale=rescale)
 
     @property
+    def device(self) -> str:
+        return self.flyweight.device
+
+    def to(self, new_device: str):
+        if self.flyweight.device != new_device:
+            self.flyweight.to(new_device)
+        self._move_local_tensors(new_device)
+
+    def _move_local_tensors(self, new_device: str):
+        self._default_normalizer = self._default_normalizer.to(new_device)
+
+
+    @property
     def shape(self) -> tuple[int, int]:
         return self._shape
 
@@ -59,6 +80,7 @@ class StaticBackgroundArray(ArrayLike):
     def normalizer(self) -> torch.Tensor:
         if not hasattr(self.flyweight, "normalizer"):
             return self._default_normalizer
+        return self.flyweight.normalizer
 
     @property
     def rescale(self):
@@ -79,7 +101,7 @@ class StaticBackgroundArray(ArrayLike):
         cropped_baseline = self.baseline[item]
         if self.rescale:
             cropped_normalizer = self.normalizer[item]
-            cropped_baseline *= cropped_normalize
+            return cropped_baseline * cropped_normalizer
 
         return cropped_baseline
 

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -103,6 +103,18 @@ class DemixingResults(Serializer):
         "residual_roi_averages"
     }
 
+    """
+    This lists arrays which are explicitly managed by demixing results.
+    When you do DemixingResults.to(new_device), this object is responsible for making sure all of these arrays are moved to that device
+    """
+    _managed_arrays = ["pmd_array",
+                       "ac_array",
+                       "colorful_ac_array",
+                       "fluctuating_background_array",
+                       "static_background_array",
+                       "standard_correlation_images",
+                       "residual_correlation_images",
+                       ]
     def __init__(
             self,
             shape: Tuple[int, int, int] | np.ndarray,
@@ -160,85 +172,76 @@ class DemixingResults(Serializer):
         """
         self._device = device
         self._shape = tuple(shape)
-        self._u_sparse = u.to(self.device).float().coalesce()
-        self._v = v.to(self.device).float()
-        self._a = a.to(self.device).float().coalesce()
-        self._c = c.to(self.device).float()
-
         self._flyweight = TensorFlyWeight()
+        self.flyweight.u = u.to(self.device).float().coalesce()
+        self.flyweight.v = v.to(self.device).float()
+        self.flyweight.a = a.to(self.device).float().coalesce()
+        self.flyweight.c = c.to(self.device).float()
 
-        if pmd_mean_img is not None:
-            self._pmd_mean_img = pmd_mean_img
-        else:
-            self._pmd_mean_img = torch.zeros(self.shape[1], self.shape[2], device=self.device)
-        if pmd_var_img is not None:
-            self._pmd_var_img = pmd_var_img
-        else:
-            self._pmd_var_img= torch.ones(self.shape[1], self.shape[2], device=self.device)
+        self.flyweight.pmd_mean_img = pmd_mean_img if pmd_mean_img is not None else torch.zeros(self.shape[1], self.shape[2], device=self.device)
+        self.flyweight.pmd_var_img = pmd_var_img if pmd_var_img is not None else torch.ones(self.shape[1], self.shape[2], device=self.device)
+        ## Below two lines are for compatibility with existing results
+        self.flyweight.mean_img = self.flyweight.pmd_mean_img
+        self.flyweight.var_img = self.flyweight.pmd_var_img
 
-        self._pmd_u_projector = pmd_u_projector.coalesce() if pmd_u_projector is not None else None
+        #This is called
+        self.flyweight.normalizer = self.flyweight.pmd_var_img
+
+        self.flyweight.pmd_u_projector = pmd_u_projector.float().coalesce() if pmd_u_projector is not None else None
 
         if factorized_bkgd_term1 is None or factorized_bkgd_term2 is None:
             display("Background term empty")
-            self._factorized_bkgd_term1 = torch.zeros(self.u.shape[1], 1, dtype=self.u.dtype, device=self.device)
-            self._factorized_bkgd_term2 = torch.zeros((1, self.v.shape[1]), dtype=self.u.dtype, device=self.device)
+            self.flyweight.factorized_bkgd_term1 = torch.zeros(self.u.shape[1], 1, dtype=self.u.dtype, device=self.device)
+            self.flyweight.factorized_bkgd_term2 = torch.zeros((1, self.v.shape[1]), dtype=self.u.dtype, device=self.device)
         else:
-            self._factorized_bkgd_term1 = factorized_bkgd_term1.to(self.device)
-            self._factorized_bkgd_term2 = factorized_bkgd_term2.to(self.device)
+            self.flyweight.factorized_bkgd_term1 = factorized_bkgd_term1.to(self.device)
+            self.flyweight.factorized_bkgd_term2 = factorized_bkgd_term2.to(self.device)
 
-        if global_residual_correlation_image is None:
-            self._global_residual_corr_img = torch.zeros(self.shape[1], self.shape[2], device=self.device, dtype=self._u_sparse.dtype)
-        else:
-            self._global_residual_corr_img = global_residual_correlation_image
+        self.flyweight.global_residual_correlation_image = global_residual_correlation_image if global_residual_correlation_image is not None else torch.zeros(self.shape[1], self.shape[2], device=self.device, dtype=self._u_sparse.dtype)
+
 
         if b is None:
             display("Static term was not provided, constructing baseline to ensure residual is mean 0")
-            self._b = (torch.sparse.mm(self.u, torch.mean(self.v, dim=1, keepdim=True)) -
-                       torch.sparse.mm(self._a, torch.mean(self._c.T, dim=1, keepdim=True)) -
+            self.flyweight.b = (torch.sparse.mm(self.u, torch.mean(self.v, dim=1, keepdim=True)) -
+                       torch.sparse.mm(self.a, torch.mean(self.c.T, dim=1, keepdim=True)) -
                        torch.sparse.mm(self.u, (
                                    self.factorized_bkgd_term1 @ torch.mean(self.factorized_bkgd_term2, axis=1,
                                                                            keepdim=True))))
         else:
-            self._b = b
-        self._baseline = self._b.reshape(self.fov_shape)
+            self.flyweight.b = b
+        self.flyweight.baseline = self.b.reshape(self.fov_shape)
 
-        if pmd_roi_averages is not None:
-            self._pmd_roi_averages = pmd_roi_averages
-        else:
-            self._pmd_roi_averages = None
+        self.flyweight.pmd_roi_averages = pmd_roi_averages
+        self.flyweight.fluctuating_background_roi_averages = fluctuating_background_roi_averages
+        self.flyweight.residual_roi_averages = residual_roi_averages
 
-        if fluctuating_background_roi_averages is not None:
-            self._fluctuating_background_roi_averages = fluctuating_background_roi_averages
-        else:
-            self._fluctuating_background_roi_averages = None
+        ## Set the roi averages above that are None
+        self._set_roi_averages()
 
-        if residual_roi_averages is not None:
-            self._residual_roi_averages = residual_roi_averages
-        else:
-            self._residual_roi_averages = None
+
 
         if std_corr_img_mean is None or std_corr_img_normalizer is None:
-            self._std_corr_img_mean = None
-            self._std_corr_img_normalizer = None
+            self.flyweight.std_corr_img_mean = None
+            self.flyweight.std_corr_img_normalizer = None
         else:
-            self._std_corr_img_mean = std_corr_img_mean  # standard_correlation_image.movie_mean
-            self._std_corr_img_normalizer = std_corr_img_normalizer  # standard_correlation_image.movie_normalizer
+            self.flyweight.std_corr_img_mean = std_corr_img_mean  # standard_correlation_image.movie_mean
+            self.flyweight.std_corr_img_normalizer = std_corr_img_normalizer  # standard_correlation_image.movie_normalizer
 
         if resid_corr_img_mean is None or resid_corr_img_support_values is None or resid_corr_img_normalizer is None:
-            self._resid_corr_img_support_values = None
-            self._resid_corr_img_mean = None
-            self._resid_corr_img_normalizer = None
+            self.flyweight.resid_corr_img_support_values = None
+            self.flyweight.resid_corr_img_mean = None
+            self.flyweight.resid_corr_img_normalizer = None
         else:
-            self._resid_corr_img_support_values = resid_corr_img_support_values.coalesce()
-            self._resid_corr_img_mean = resid_corr_img_mean
-            self._resid_corr_img_normalizer = resid_corr_img_normalizer
+            self.flyweight.resid_corr_img_support_values = resid_corr_img_support_values.coalesce()
+            self.flyweight.resid_corr_img_mean = resid_corr_img_mean
+            self.flyweight.resid_corr_img_normalizer = resid_corr_img_normalizer
 
         if bkgd_corr_img_mean is None or bkgd_corr_img_normalizer is None:
-            self._bkgd_corr_img_mean = None
-            self._bkgd_corr_img_normalizer = None
+            self.flyweight.bkgd_corr_img_mean = None
+            self.flyweight.bkgd_corr_img_normalizer = None
         else:
-            self._bkgd_corr_img_mean = bkgd_corr_img_mean
-            self._bkgd_corr_img_normalizer = bkgd_corr_img_normalizer
+            self.flyweight.bkgd_corr_img_mean = bkgd_corr_img_mean
+            self.flyweight.bkgd_corr_img_normalizer = bkgd_corr_img_normalizer
 
         self._ac_array = None
         self._colorful_ac_array = None
@@ -249,10 +252,18 @@ class DemixingResults(Serializer):
         self._residual_correlation_images = None
         self._standard_correlation_images = None
 
-        self._rescale = False
-
+        #Manage state of relevant arrays
+        self.rescale = False
         # Move all tracked tensors to desired location so everything is on one device
         self.to(self.device)
+
+    @property
+    def flyweight(self) -> TensorFlyWeight:
+        return self._flyweight
+
+    @property
+    def device(self) -> str:
+        return self.flyweight.device
 
     @property
     def rescale(self):
@@ -260,119 +271,74 @@ class DemixingResults(Serializer):
 
     @rescale.setter
     def rescale(self, new_value: bool):
-        self._rescale = new_value
+        managed_arrays_rescale = ['pmd_array',
+                          'ac_array',
+                          'static_background_array',
+                          'fluctuating_background_array']
 
-        self.pmd_array.rescale = new_value
-        self.ac_array.rescale = new_value
-        self.static_background_array.rescale = new_value
-        self.fluctuating_background_array.rescale = new_value
+        self._rescale = new_value
+        for name in managed_arrays_rescale:
+            arr = getattr(self, name)
+            arr.rescale = new_value
 
     @property
-    def pmd_mean_img(self) -> Union[None, torch.Tensor]:
-        return self._pmd_mean_img
+    def pmd_mean_img(self) -> torch.Tensor:
+        return self.flyweight.pmd_mean_img
 
     @property
     def mean_img(self) -> torch.Tensor:
-        return self._pmd_mean_img
+        """
+        Property added for compatibility purposes -- identical to pmd mean img
+        """
+        return self.flyweight.mean_img
 
     @property
-    def pmd_var_img(self) -> Union[None, torch.Tensor]:
-        return self._pmd_var_img
+    def pmd_var_img(self) -> torch.Tensor:
+        return self.flyweight.pmd_var_img
 
     @property
     def var_img(self) -> torch.Tensor:
-        return self._pmd_var_img
+        """
+        Property added for compatibility purposes -- identical to pmd var img
+        """
+        return self.flyweight.var_img
 
     @property
     def normalizer(self) -> torch.Tensor:
-        return self._pmd_var_img
+        return self.flyweight.normalizer
 
     @property
-    def pmd_u_projector(self) -> Union[None, torch.Tensor]:
-        return self._pmd_u_projector
+    def pmd_u_projector(self) -> None | torch.Tensor:
+        return self.flyweight.pmd_u_projector
 
     @property
-    def factorized_bkgd_term1(self) -> Union[None, torch.Tensor]:
-        return self._factorized_bkgd_term1
+    def factorized_bkgd_term1(self) -> None | torch.Tensor:
+        return self.flyweight.factorized_bkgd_term1
 
     @property
-    def factorized_bkgd_term2(self) -> Union[None, torch.Tensor]:
-        return self._factorized_bkgd_term2
+    def factorized_bkgd_term2(self) -> None | torch.Tensor:
+        return self.flyweight.factorized_bkgd_term2
 
     @property
     def shape(self):
         return self._shape
 
     @property
-    def order(self):
-        return self._order
-
-    @property
     def device(self):
-        return self._device
+        return self.flyweight.device
 
     def to(self, new_device):
-        self._move_managed_tensors(new_device)
-
+        self.flyweight.to(new_device)
         self._move_managed_arrays(new_device)
 
 
     def _move_managed_tensors(self, new_device: str):
-        self._device = new_device
-        self._u_sparse = self._u_sparse.to(self.device)
-        self._factorized_bkgd_term1 = self._factorized_bkgd_term1.to(self.device)
-        self._factorized_bkgd_term2 = self._factorized_bkgd_term2.to(self.device)
-        self._v = self._v.to(self.device)
-        self._a = self._a.to(self.device)
-        self._c = self._c.to(self.device)
-        self._b = self._b.to(self.device)
-        self._baseline = self._baseline.to(self.device)
-
-        if self._pmd_mean_img is not None:
-            self._pmd_mean_img = self._pmd_mean_img.to(self.device)
-        if self._pmd_var_img is not None:
-            self._pmd_var_img = self._pmd_var_img.to(self.device)
-        if self._pmd_u_projector is not None:
-            self._pmd_u_projector.to(self.device)
-
-        if self._std_corr_img_mean is not None:  # This means all the std corr img data is not None from init logic
-            self._std_corr_img_mean = self._std_corr_img_mean.to(self.device)
-            self._std_corr_img_normalizer = self._std_corr_img_normalizer.to(self.device)
-
-        if self._bkgd_corr_img_mean is not None:  # This means all the bkgd corr img data is not None from init logic
-            self._bkgd_corr_img_mean = self._bkgd_corr_img_mean.to(self.device)
-            self._bkgd_corr_img_normalizer = self._bkgd_corr_img_normalizer.to(self.device)
-
-        if self._resid_corr_img_mean is not None:  # This means all the resid corr img data is not None from init logic
-            self._resid_corr_img_support_values = self._resid_corr_img_support_values.to(self.device)
-            self._resid_corr_img_mean = self._resid_corr_img_mean.to(self.device)
-            self._resid_corr_img_normalizer = self._resid_corr_img_normalizer.to(self.device)
-
-        if self._global_residual_corr_img is not None:
-            self._global_residual_corr_img = self._global_residual_corr_img.to(self.device)
+        self.flyweight.to(new_device)
 
     def _move_managed_arrays(self, new_device: str):
-
-        if self._ac_array is not None:
-            self.ac_array.to(self.device)
-
-        if self._colorful_ac_array is not None:
-            self.colorful_ac_array.to(self.device)
-
-        if self._pmd_array is not None:
-            self.pmd_array.to(self.device)
-
-        if self._fluctuating_background_array is not None:
-            self.fluctuating_background_array.to(self.device)
-
-        if self._static_background_array is not None:
-            self.static_background_array.to(self.device)
-
-        if self._residual_correlation_images is not None:
-            self.residual_correlation_images.to(self.device)
-
-        if self._standard_correlation_images is not None:
-            self.standard_correlation_images.to(self.device)
+        for arr_name in self._managed_arrays:
+            curr_arr = getattr(self, arr_name)
+            curr_arr.to(self.device)
 
     @property
     def fov_shape(self) -> Tuple[int, int]:
@@ -383,67 +349,70 @@ class DemixingResults(Serializer):
         return self.shape[0]
 
     @property
-    def u(self) -> torch.sparse_coo_tensor:
-        return self._u_sparse
+    def u(self) -> torch.Tensor:
+        return self.flyweight.u
 
     @property
     def b(self) -> torch.Tensor:
-        return self._b
+        return self.flyweight.b
 
     @property
     def baseline(self) -> torch.Tensor:
-        return self._baseline
+        """
+        Returns a (height, width)-shaped 2D tensor
+        """
+        return self.flyweight.baseline
 
     @property
-    def v(self) -> torch.tensor:
-        return self._v
+    def v(self) -> torch.Tensor:
+        return self.flyweight.v
 
     @property
-    def a(self) -> torch.sparse_coo_tensor:
-        return self._a
+    def a(self) -> torch.Tensor:
+        return self.flyweight.a
 
     @property
-    def c(self) -> torch.tensor:
-        return self._c
+    def c(self) -> torch.Tensor:
+        return self.flyweight.c
 
     @property
-    def std_corr_img_mean(self) -> Union[None, torch.Tensor]:
-        return self._std_corr_img_mean
+    def std_corr_img_mean(self) -> None | torch.Tensor:
+        return self.flyweight.std_corr_img_mean
 
     @property
-    def std_corr_img_normalizer(self) -> Union[None, torch.Tensor]:
-        return self._std_corr_img_normalizer
+    def std_corr_img_normalizer(self) -> None | torch.Tensor:
+        return self.flyweight.std_corr_img_normalizer
 
     @property
-    def resid_corr_img_support_values(self) -> Union[None, torch.sparse_coo_tensor]:
-        return self._resid_corr_img_support_values
+    def resid_corr_img_support_values(self) -> None | torch.Tensor:
+        return self.flyweight.resid_corr_img_support_values
 
     @property
-    def resid_corr_img_mean(self) -> Union[None, torch.Tensor]:
-        return self._resid_corr_img_mean
+    def resid_corr_img_mean(self) ->  None | torch.Tensor:
+        return self.flyweight.resid_corr_img_mean
 
     @property
-    def resid_corr_img_normalizer(self) -> Union[None, torch.Tensor]:
-        return self._resid_corr_img_normalizer
+    def resid_corr_img_normalizer(self) -> None | torch.Tensor:
+        return self.flyweight.resid_corr_img_normalizer
 
     @property
-    def global_residual_correlation_image(self) -> Union[None, torch.Tensor]:
-        return self._global_residual_corr_img
+    def global_residual_correlation_image(self) -> None | torch.Tensor:
+        return self.flyweight.global_residual_correlation_image
 
     @property
-    def bkgd_corr_img_mean(self) -> Union[None, torch.Tensor]:
-        return self._bkgd_corr_img_mean
+    def bkgd_corr_img_mean(self) -> None | torch.Tensor:
+        return self.flyweight.bkgd_corr_img_mean
 
     @property
-    def bkgd_corr_img_normalizer(self) -> Union[None, torch.Tensor]:
-        return self._bkgd_corr_img_normalizer
+    def bkgd_corr_img_normalizer(self) -> None | torch.Tensor:
+        return self.flyweight.bkgd_corr_img_normalizer
 
-    def _roi_averages(self) -> tuple[torch.tensor, torch.tensor, torch.tensor]:
+    def _set_roi_averages(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Returns the ROI averages for each spatial footprint of the AC Array in the PMD movie, fluctuating background movie,
         and residual movie.
         """
-        if self._residual_roi_averages is None or self._pmd_roi_averages is None or self._fluctuating_background_roi_averages is None:
+        if self.flyweight.residual_roi_averages is None or self.flyweight.pmd_roi_averages is None or self.flyweight.fluctuating_background_roi_averages is None:
             residual_roi_averages = torch.zeros_like(self.c)
             pmd_roi_averages = torch.zeros_like(self.c)
             fluctuating_background_roi_averages = torch.zeros_like(self.c)
@@ -469,36 +438,34 @@ class DemixingResults(Serializer):
                 fluctuating_background_roi_averages[:, k] = avg_bkgd.squeeze()
                 residual_roi_averages[:, k] = resid.squeeze()
                 avg_tensor *= 0 #Reset this
-            self._pmd_roi_averages = pmd_roi_averages
-            self._fluctuating_background_roi_averages = fluctuating_background_roi_averages
-            self._residual_roi_averages = residual_roi_averages
-
-        return (self._pmd_roi_averages, self._fluctuating_background_roi_averages, self._residual_roi_averages)
+            self.flyweight.pmd_roi_averages = pmd_roi_averages
+            self.flyweight.fluctuating_background_roi_averages = fluctuating_background_roi_averages
+            self.flyweight.residual_roi_averages = residual_roi_averages
 
     @property
-    def pmd_roi_averages(self) -> torch.tensor:
-        return self._roi_averages()[0]
+    def pmd_roi_averages(self) -> torch.Tensor:
+        return self.flyweight.pmd_roi_averages
 
     @property
-    def fluctuating_background_roi_averages(self) -> torch.tensor:
-        return self._roi_averages()[1]
+    def fluctuating_background_roi_averages(self) -> torch.Tensor:
+        return self.flyweight.fluctuating_background_roi_averages
 
     @property
-    def residual_roi_averages(self) -> torch.tensor:
-        return self._roi_averages()[2]
+    def residual_roi_averages(self) -> torch.Tensor:
+        return self.flyweight.residual_roi_averages
 
     @property
-    def standard_correlation_images(self) -> Union[None, StandardCorrelationImages]:
+    def standard_correlation_images(self) -> None | StandardCorrelationImages:
         if self.std_corr_img_mean is not None:
             if self._standard_correlation_images is None:
-                self._standard_correlation_images = StandardCorrelationImages.from_flyweight(self,
+                self._standard_correlation_images = StandardCorrelationImages.from_flyweight(self.flyweight,
                                                                                              (self._shape[1], self._shape[2]))
             return self._standard_correlation_images
         else:
             return None
 
     @property
-    def background_to_signal_correlation_image(self) -> Union[None, StandardCorrelationImages]:
+    def background_to_signal_correlation_image(self) -> None | StandardCorrelationImages:
         """
         This array will not use the FlyWeight pattern that the other arrays use, since this is primarily an exploratory
         property. If this becomes crucial, can re-organize
@@ -506,7 +473,7 @@ class DemixingResults(Serializer):
         if self.bkgd_corr_img_mean is not None:
             return StandardCorrelationImages.from_tensors(self._u_sparse,
                                              self.factorized_bkgd_term1 @ self.factorized_bkgd_term2,
-                                             self._c,
+                                             self.c,
                                              self.bkgd_corr_img_mean,
                                              self.bkgd_corr_img_normalizer,
                                              (self._shape[1], self._shape[2]))
@@ -514,10 +481,10 @@ class DemixingResults(Serializer):
             return None
 
     @property
-    def residual_correlation_images(self) -> Union[None, ResidualCorrelationImages]:
+    def residual_correlation_images(self) -> None | ResidualCorrelationImages:
         if self.resid_corr_img_mean is not None:
             if self._residual_correlation_images is None:
-                self._residual_correlation_images = ResidualCorrelationImages.from_flyweight(self,
+                self._residual_correlation_images = ResidualCorrelationImages.from_flyweight(self.flyweight,
                                                                                              (self.shape[1], self.shape[2]),
                                                                                              mode=ResidCorrMode.RESIDUAL)
             return self._residual_correlation_images
@@ -530,7 +497,7 @@ class DemixingResults(Serializer):
         Returns an ACArray using the tensors stored in this object
         """
         if self._ac_array is None:
-            self._ac_array = ACArray.from_flyweight(self.fov_shape, self, rescale=self.rescale)
+            self._ac_array = ACArray.from_flyweight(self.fov_shape, self.flyweight, rescale=self.rescale)
         return self._ac_array
 
     @property
@@ -541,7 +508,7 @@ class DemixingResults(Serializer):
         if self._pmd_array is None:
             self._pmd_array = PMDArray.from_flyweight(
                 self.shape,
-                self,
+                self.flyweight,
                 device=self.device,
                 rescale=self.rescale,
             )
@@ -554,7 +521,7 @@ class DemixingResults(Serializer):
         """
         if self._fluctuating_background_array is None:
             self._fluctuating_background_array = FluctuatingBackgroundArray.from_flyweight(self.fov_shape,
-                                                                            self,
+                                                                            self.flyweight,
                                                                             rescale=self.rescale)
         return self._fluctuating_background_array
 
@@ -562,7 +529,7 @@ class DemixingResults(Serializer):
     def static_background_array(self) -> StaticBackgroundArray:
 
         if self._static_background_array is None:
-            self._static_background_array = StaticBackgroundArray.from_flyweight(self,
+            self._static_background_array = StaticBackgroundArray.from_flyweight(self.flyweight,
                                                                              rescale = self.rescale)
         return self._static_background_array
 
@@ -579,6 +546,6 @@ class DemixingResults(Serializer):
     @property
     def colorful_ac_array(self) -> ColorfulACArray:
         if self._colorful_ac_array is None:
-            self._colorful_ac_array = ColorfulACArray.from_flyweight(self.fov_shape, self)
+            self._colorful_ac_array = ColorfulACArray.from_flyweight(self.fov_shape, self.flyweight)
         return self._colorful_ac_array
 

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -160,9 +160,9 @@ class DemixingResults(Serializer, TensorFlyWeight):
         """
         self._device = device
         self._shape = tuple(shape)
-        self._u_sparse = u.to(self.device).float()
+        self._u_sparse = u.to(self.device).float().coalesce()
         self._v = v.to(self.device).float()
-        self._a = a.to(self.device).float()
+        self._a = a.to(self.device).float().coalesce()
         self._c = c.to(self.device).float()
 
         if pmd_mean_img is not None:
@@ -174,7 +174,7 @@ class DemixingResults(Serializer, TensorFlyWeight):
         else:
             self._pmd_var_img= torch.ones(self.shape[1], self.shape[2], device=self.device)
 
-        self._pmd_u_projector = pmd_u_projector
+        self._pmd_u_projector = pmd_u_projector.coalesce() if pmd_u_projector is not None else None
 
         if factorized_bkgd_term1 is None or factorized_bkgd_term2 is None:
             display("Background term empty")
@@ -219,7 +219,7 @@ class DemixingResults(Serializer, TensorFlyWeight):
             self._resid_corr_img_mean = None
             self._resid_corr_img_normalizer = None
         else:
-            self._resid_corr_img_support_values = resid_corr_img_support_values
+            self._resid_corr_img_support_values = resid_corr_img_support_values.coalesce()
             self._resid_corr_img_mean = resid_corr_img_mean
             self._resid_corr_img_normalizer = resid_corr_img_normalizer
 

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -2,7 +2,7 @@ from typing import *
 import numpy as np
 from masknmf import display
 from masknmf.compression import PMDArray
-from masknmf.demixing.demixing_arrays import ACArray, ResidualCorrelationImages, StandardCorrelationImages, ColorfulACArray, StaticBaselineArray, FluctuatingBackgroundArray, ResidualArray, ResidCorrMode
+from masknmf.demixing.demixing_arrays import ACArray, ResidualCorrelationImages, StandardCorrelationImages, ColorfulACArray, StaticBackgroundArray, FluctuatingBackgroundArray, ResidualArray, ResidCorrMode
 import torch
 from masknmf.utils import Serializer
 from masknmf.arrays.array_interfaces import TensorFlyWeight
@@ -156,11 +156,9 @@ class DemixingResults(Serializer, TensorFlyWeight):
             bkgd_corr_img_mean (Optional[torch.Tensor]): The mean image used to compute the correlation between the signal and the background.
             bkgd_corr_img_normalizer (Optional[torch.Tensor]): The mean image used to compute the correlation between the signal and the background.
             global_resid_correlation_image (torch.Tensor): The global correlation image of the residual. Shape (FOV dim 1, FOV dim 2).
-            order (str): order used to reshape data from 2D to 1D
             device (str): 'cpu' or 'cuda'. used to manage where the tensors reside
         """
         self._device = device
-        self._order = order
         self._shape = tuple(shape)
         self._u_sparse = u.to(self.device).float()
         self._v = v.to(self.device).float()
@@ -200,6 +198,7 @@ class DemixingResults(Serializer, TensorFlyWeight):
                                                                            keepdim=True))))
         else:
             self._b = b
+        self._baseline = self._b.reshape(self.fov_shape)
 
         if pmd_roi_averages is not None:
             self._pmd_roi_averages = pmd_roi_averages
@@ -242,6 +241,7 @@ class DemixingResults(Serializer, TensorFlyWeight):
         self._colorful_ac_array = None
         self._pmd_array = None
         self._fluctuating_background_array = None
+        self._static_background_array = None
         self._residual_array = None
         self._residual_correlation_images = None
         self._standard_correlation_images = None
@@ -266,7 +266,15 @@ class DemixingResults(Serializer, TensorFlyWeight):
         return self._pmd_mean_img
 
     @property
+    def mean_img(self) -> torch.Tensor:
+        return self._pmd_mean_img
+
+    @property
     def pmd_var_img(self) -> Union[None, torch.Tensor]:
+        return self._pmd_var_img
+
+    @property
+    def var_img(self) -> torch.Tensor:
         return self._pmd_var_img
 
     @property
@@ -306,6 +314,7 @@ class DemixingResults(Serializer, TensorFlyWeight):
         self._a = self._a.to(self.device)
         self._c = self._c.to(self.device)
         self._b = self._b.to(self.device)
+        self._baseline = self._baseline.to(self.device)
 
         if self._pmd_mean_img is not None:
             self._pmd_mean_img = self._pmd_mean_img.to(self.device)
@@ -343,8 +352,12 @@ class DemixingResults(Serializer, TensorFlyWeight):
         return self._u_sparse
 
     @property
-    def b(self) -> torch.tensor:
+    def b(self) -> torch.Tensor:
         return self._b
+
+    @property
+    def baseline(self) -> torch.Tensor:
+        return self._baseline
 
     @property
     def v(self) -> torch.tensor:
@@ -511,11 +524,12 @@ class DemixingResults(Serializer, TensorFlyWeight):
         return self._fluctuating_background_array
 
     @property
-    def baseline(self) -> StaticBaselineArray:
-        if self._static_baseline_array is None:
-            self._static_baseline_array = StaticBaselineArray.from_flyweight(self,
+    def static_background_array(self) -> StaticBackgroundArray:
+
+        if self._static_background_array is None:
+            self._static_background_array = StaticBackgroundArray.from_flyweight(self,
                                                                              rescale = self.rescale)
-        return self._static_baseline_array
+        return self._static_background_array
 
     @property
     def residual_array(self) -> ResidualArray:
@@ -523,7 +537,7 @@ class DemixingResults(Serializer, TensorFlyWeight):
             self._residual_array = ResidualArray(self.pmd_array,
                                                 self.ac_array,
                                                 self.fluctuating_background_array,
-                                                self.baseline,
+                                                self.static_background_array,
                                             )
         return self._residual_array
 

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -77,7 +77,7 @@ def test_spatial_crop_effect(my_tuple, spatial_dims) -> bool:
                 return True
     return False
 
-class DemixingResults(Serializer, TensorFlyWeight):
+class DemixingResults(Serializer):
     _serialized = {
         "shape",
         "u",
@@ -165,6 +165,8 @@ class DemixingResults(Serializer, TensorFlyWeight):
         self._a = a.to(self.device).float().coalesce()
         self._c = c.to(self.device).float()
 
+        self._flyweight = TensorFlyWeight()
+
         if pmd_mean_img is not None:
             self._pmd_mean_img = pmd_mean_img
         else:
@@ -202,10 +204,18 @@ class DemixingResults(Serializer, TensorFlyWeight):
 
         if pmd_roi_averages is not None:
             self._pmd_roi_averages = pmd_roi_averages
+        else:
+            self._pmd_roi_averages = None
+
         if fluctuating_background_roi_averages is not None:
             self._fluctuating_background_roi_averages = fluctuating_background_roi_averages
+        else:
+            self._fluctuating_background_roi_averages = None
+
         if residual_roi_averages is not None:
             self._residual_roi_averages = residual_roi_averages
+        else:
+            self._residual_roi_averages = None
 
         if std_corr_img_mean is None or std_corr_img_normalizer is None:
             self._std_corr_img_mean = None
@@ -229,10 +239,6 @@ class DemixingResults(Serializer, TensorFlyWeight):
         else:
             self._bkgd_corr_img_mean = bkgd_corr_img_mean
             self._bkgd_corr_img_normalizer = bkgd_corr_img_normalizer
-
-        self._pmd_roi_averages = None
-        self._fluctuating_background_roi_averages = None
-        self._residual_roi_averages = None
 
         self._ac_array = None
         self._colorful_ac_array = None

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -230,9 +230,6 @@ class DemixingResults(Serializer, TensorFlyWeight):
             self._bkgd_corr_img_mean = bkgd_corr_img_mean
             self._bkgd_corr_img_normalizer = bkgd_corr_img_normalizer
 
-        # Move all tracked tensors to desired location so everything is on one device
-        self.to(self.device)
-
         self._pmd_roi_averages = None
         self._fluctuating_background_roi_averages = None
         self._residual_roi_averages = None
@@ -248,6 +245,9 @@ class DemixingResults(Serializer, TensorFlyWeight):
 
         self._rescale = False
 
+        # Move all tracked tensors to desired location so everything is on one device
+        self.to(self.device)
+
     @property
     def rescale(self):
         return self._rescale
@@ -258,7 +258,7 @@ class DemixingResults(Serializer, TensorFlyWeight):
 
         self.pmd_array.rescale = new_value
         self.ac_array.rescale = new_value
-        self.baseline.rescale = new_value
+        self.static_background_array.rescale = new_value
         self.fluctuating_background_array.rescale = new_value
 
     @property
@@ -306,6 +306,12 @@ class DemixingResults(Serializer, TensorFlyWeight):
         return self._device
 
     def to(self, new_device):
+        self._move_managed_tensors(new_device)
+
+        self._move_managed_arrays(new_device)
+
+
+    def _move_managed_tensors(self, new_device: str):
         self._device = new_device
         self._u_sparse = self._u_sparse.to(self.device)
         self._factorized_bkgd_term1 = self._factorized_bkgd_term1.to(self.device)
@@ -323,21 +329,44 @@ class DemixingResults(Serializer, TensorFlyWeight):
         if self._pmd_u_projector is not None:
             self._pmd_u_projector.to(self.device)
 
-        if self._std_corr_img_mean is not None: #This means all the std corr img data is not None from init logic
+        if self._std_corr_img_mean is not None:  # This means all the std corr img data is not None from init logic
             self._std_corr_img_mean = self._std_corr_img_mean.to(self.device)
             self._std_corr_img_normalizer = self._std_corr_img_normalizer.to(self.device)
 
-        if self._bkgd_corr_img_mean is not None: #This means all the bkgd corr img data is not None from init logic
+        if self._bkgd_corr_img_mean is not None:  # This means all the bkgd corr img data is not None from init logic
             self._bkgd_corr_img_mean = self._bkgd_corr_img_mean.to(self.device)
             self._bkgd_corr_img_normalizer = self._bkgd_corr_img_normalizer.to(self.device)
 
-        if self._resid_corr_img_mean is not None: #This means all the resid corr img data is not None from init logic
+        if self._resid_corr_img_mean is not None:  # This means all the resid corr img data is not None from init logic
             self._resid_corr_img_support_values = self._resid_corr_img_support_values.to(self.device)
             self._resid_corr_img_mean = self._resid_corr_img_mean.to(self.device)
             self._resid_corr_img_normalizer = self._resid_corr_img_normalizer.to(self.device)
 
         if self._global_residual_corr_img is not None:
             self._global_residual_corr_img = self._global_residual_corr_img.to(self.device)
+
+    def _move_managed_arrays(self, new_device: str):
+
+        if self._ac_array is not None:
+            self.ac_array.to(self.device)
+
+        if self._colorful_ac_array is not None:
+            self.colorful_ac_array.to(self.device)
+
+        if self._pmd_array is not None:
+            self.pmd_array.to(self.device)
+
+        if self._fluctuating_background_array is not None:
+            self.fluctuating_background_array.to(self.device)
+
+        if self._static_background_array is not None:
+            self.static_background_array.to(self.device)
+
+        if self._residual_correlation_images is not None:
+            self.residual_correlation_images.to(self.device)
+
+        if self._standard_correlation_images is not None:
+            self.standard_correlation_images.to(self.device)
 
     @property
     def fov_shape(self) -> Tuple[int, int]:

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -197,7 +197,7 @@ class DemixingResults(Serializer):
             self.flyweight.factorized_bkgd_term1 = factorized_bkgd_term1.to(self.device)
             self.flyweight.factorized_bkgd_term2 = factorized_bkgd_term2.to(self.device)
 
-        self.flyweight.global_residual_correlation_image = global_residual_correlation_image if global_residual_correlation_image is not None else torch.zeros(self.shape[1], self.shape[2], device=self.device, dtype=self._u_sparse.dtype)
+        self.flyweight.global_residual_correlation_image = global_residual_correlation_image if global_residual_correlation_image is not None else torch.zeros(self.shape[1], self.shape[2], device=self.device, dtype=self.u.dtype)
 
 
         if b is None:
@@ -471,7 +471,7 @@ class DemixingResults(Serializer):
         property. If this becomes crucial, can re-organize
         """
         if self.bkgd_corr_img_mean is not None:
-            return StandardCorrelationImages.from_tensors(self._u_sparse,
+            return StandardCorrelationImages.from_tensors(self.u,
                                              self.factorized_bkgd_term1 @ self.factorized_bkgd_term2,
                                              self.c,
                                              self.bkgd_corr_img_mean,

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -102,6 +102,12 @@ class DemixingResults(Serializer):
         "residual_roi_averages"
     }
 
+    MANAGED_ARRAYS = ['ac_array',
+                      'pmd_array',
+                      'colorful_ac_array',
+                      'residual_array',
+                      'fluctuating_background_array']
+
     def __init__(
             self,
             shape: Tuple[int, int, int] | np.ndarray,
@@ -237,6 +243,27 @@ class DemixingResults(Serializer):
         self._pmd_roi_averages = None
         self._fluctuating_background_roi_averages = None
         self._residual_roi_averages = None
+
+        self._ac_array = None
+        self._colorful_ac_array = None
+        self._pmd_array = None
+        self._fluctuating_background_array = None
+        self._residual_array = None
+        self._residual_correlation_images = None
+        self._standard_correlation_images = None
+
+        self._rescale = False
+
+    @property
+    def rescale(self):
+        return self._rescale
+
+    @rescale.setter
+    def rescale(self, new_value: bool):
+        self._rescale = new_value
+        for name in MANAGED_ARRAYS:
+            array = getattr(self, f'_{name}')
+            array.rescale = self._rescale
 
     @property
     def pmd_mean_img(self) -> Union[None, torch.Tensor]:
@@ -413,15 +440,17 @@ class DemixingResults(Serializer):
         return self._roi_averages()[2]
 
     @property
-    def standard_correlation_image(self) -> Union[None, StandardCorrelationImages]:
+    def standard_correlation_images(self) -> Union[None, StandardCorrelationImages]:
         if self.std_corr_img_mean is not None:
-            return StandardCorrelationImages(self._u_sparse,
-                                             self._v,
-                                             self._c,
-                                             self.std_corr_img_mean,
-                                             self.std_corr_img_normalizer,
-                                             (self._shape[1], self._shape[2]),
-                                             order=self.order)
+            if self._standard_correlation_images is None:
+                self._standard_correlation_images = StandardCorrelationImages(self._u_sparse,
+                                                 self._v,
+                                                 self._c,
+                                                 self.std_corr_img_mean,
+                                                 self.std_corr_img_normalizer,
+                                                 (self._shape[1], self._shape[2]),
+                                                 order=self.order)
+            return self._standard_correlation_images
         else:
             return None
 
@@ -439,19 +468,21 @@ class DemixingResults(Serializer):
             return None
 
     @property
-    def residual_correlation_image(self) -> Union[None, ResidualCorrelationImages]:
+    def residual_correlation_images(self) -> Union[None, ResidualCorrelationImages]:
         if self.resid_corr_img_mean is not None:
-            return ResidualCorrelationImages(self.u,
-                                             self.v,
-                                             (self.factorized_bkgd_term1, self.factorized_bkgd_term2),
-                                             self.a,
-                                             self.c,
-                                             self.resid_corr_img_support_values,
-                                             self.resid_corr_img_mean,
-                                             self.resid_corr_img_normalizer,
-                                             (self.shape[1], self.shape[2]),
-                                             mode=ResidCorrMode.RESIDUAL,
-                                             order=self._order)
+            if self._residual_correlation_images is None:
+                self._residual_correlation_images = ResidualCorrelationImages(self.u,
+                                                 self.v,
+                                                 (self.factorized_bkgd_term1, self.factorized_bkgd_term2),
+                                                 self.a,
+                                                 self.c,
+                                                 self.resid_corr_img_support_values,
+                                                 self.resid_corr_img_mean,
+                                                 self.resid_corr_img_normalizer,
+                                                 (self.shape[1], self.shape[2]),
+                                                 mode=ResidCorrMode.RESIDUAL,
+                                                 order=self._order)
+            return self._residual_correlation_images
         else:
             return None
 
@@ -460,45 +491,54 @@ class DemixingResults(Serializer):
         """
         Returns an ACArray using the tensors stored in this object
         """
-        return ACArray(self.fov_shape, self.a, self.c)
+        if self._ac_array is None:
+            self._ac_array = ACArray(self.fov_shape, self.a, self.c)
+        return self._ac_array
 
     @property
     def pmd_array(self) -> PMDArray:
         """
         Returns a PMDArray using the tensors stored in this object
         """
-        return PMDArray(
-            self.shape,
-            self.u,
-            self.v,
-            self.pmd_mean_img,
-            self.pmd_var_img,
-            u_local_projector=self.pmd_u_projector,
-            device=self.device,
-            rescale=True,
-        )
+        if self._pmd_array is None:
+            self._pmd_array = PMDArray(
+                self.shape,
+                self.u,
+                self.v,
+                self.pmd_mean_img,
+                self.pmd_var_img,
+                u_local_projector=self.pmd_u_projector,
+                device=self.device,
+                rescale=self._rescale,
+            )
+        return self._pmd_array
 
     @property
     def fluctuating_background_array(self) -> FluctuatingBackgroundArray:
         """
         Returns a PMDArray using the tensors stored in this object
         """
-        return FluctuatingBackgroundArray(self.fov_shape,
+        if self._fluctuating_background_array is None:
+            self._fluctuating_background_array = FluctuatingBackgroundArray(self.fov_shape,
                                           self.order,
                                           self.u,
                                           self.factorized_bkgd_term1,
                                           self.factorized_bkgd_term2)
+        return self._fluctuating_background_array
 
     @property
     def residual_array(self) -> ResidualArray:
-        return ResidualArray(
-            self.pmd_array,
-            self.ac_array,
-            self.fluctuating_background_array,
-            self.b.reshape(self.fov_shape),
-        )
+        if self._residual_array is None:
+            self._residual_array = ResidualArray(self.pmd_array,
+                                                self.ac_array,
+                                                self.fluctuating_background_array,
+                                                self.b.reshape(self.fov_shape),
+                                            )
+        return self._residual_array
 
     @property
     def colorful_ac_array(self) -> ColorfulACArray:
-        return ColorfulACArray(self.fov_shape, self.a, self.c)
+        if self._colorful_ac_array is None:
+            self._colorful_ac_array = ColorfulACArray(self.fov_shape, self.a, self.c)
+        return self._colorful_ac_array
 

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -520,7 +520,6 @@ class DemixingResults(Serializer):
         """
         if self._fluctuating_background_array is None:
             self._fluctuating_background_array = FluctuatingBackgroundArray(self.fov_shape,
-                                          self.order,
                                           self.u,
                                           self.factorized_bkgd_term1,
                                           self.factorized_bkgd_term2)

--- a/masknmf/demixing/demixing_results.py
+++ b/masknmf/demixing/demixing_results.py
@@ -2,9 +2,10 @@ from typing import *
 import numpy as np
 from masknmf import display
 from masknmf.compression import PMDArray
-from masknmf.demixing.demixing_arrays import ACArray, ResidualCorrelationImages, StandardCorrelationImages, ColorfulACArray, FluctuatingBackgroundArray, ResidualArray, ResidCorrMode
+from masknmf.demixing.demixing_arrays import ACArray, ResidualCorrelationImages, StandardCorrelationImages, ColorfulACArray, StaticBaselineArray, FluctuatingBackgroundArray, ResidualArray, ResidCorrMode
 import torch
 from masknmf.utils import Serializer
+from masknmf.arrays.array_interfaces import TensorFlyWeight
 
 
 def test_slice_effect(my_slice: slice, spatial_dim: int) -> bool:
@@ -76,7 +77,7 @@ def test_spatial_crop_effect(my_tuple, spatial_dims) -> bool:
                 return True
     return False
 
-class DemixingResults(Serializer):
+class DemixingResults(Serializer, TensorFlyWeight):
     _serialized = {
         "shape",
         "u",
@@ -102,12 +103,6 @@ class DemixingResults(Serializer):
         "residual_roi_averages"
     }
 
-    MANAGED_ARRAYS = ['ac_array',
-                      'pmd_array',
-                      'colorful_ac_array',
-                      'residual_array',
-                      'fluctuating_background_array']
-
     def __init__(
             self,
             shape: Tuple[int, int, int] | np.ndarray,
@@ -132,7 +127,6 @@ class DemixingResults(Serializer):
             pmd_roi_averages: Optional[torch.Tensor] = None,
             fluctuating_background_roi_averages: Optional[torch.Tensor] = None,
             residual_roi_averages: Optional[torch.Tensor] = None,
-            order: str = "C",
             device="cpu",
     ):
         """
@@ -261,9 +255,11 @@ class DemixingResults(Serializer):
     @rescale.setter
     def rescale(self, new_value: bool):
         self._rescale = new_value
-        for name in MANAGED_ARRAYS:
-            array = getattr(self, f'_{name}')
-            array.rescale = self._rescale
+
+        self.pmd_array.rescale = new_value
+        self.ac_array.rescale = new_value
+        self.baseline.rescale = new_value
+        self.fluctuating_background_array.rescale = new_value
 
     @property
     def pmd_mean_img(self) -> Union[None, torch.Tensor]:
@@ -271,6 +267,10 @@ class DemixingResults(Serializer):
 
     @property
     def pmd_var_img(self) -> Union[None, torch.Tensor]:
+        return self._pmd_var_img
+
+    @property
+    def normalizer(self) -> torch.Tensor:
         return self._pmd_var_img
 
     @property
@@ -443,27 +443,25 @@ class DemixingResults(Serializer):
     def standard_correlation_images(self) -> Union[None, StandardCorrelationImages]:
         if self.std_corr_img_mean is not None:
             if self._standard_correlation_images is None:
-                self._standard_correlation_images = StandardCorrelationImages(self._u_sparse,
-                                                 self._v,
-                                                 self._c,
-                                                 self.std_corr_img_mean,
-                                                 self.std_corr_img_normalizer,
-                                                 (self._shape[1], self._shape[2]),
-                                                 order=self.order)
+                self._standard_correlation_images = StandardCorrelationImages.from_flyweight(self,
+                                                                                             (self._shape[1], self._shape[2]))
             return self._standard_correlation_images
         else:
             return None
 
     @property
     def background_to_signal_correlation_image(self) -> Union[None, StandardCorrelationImages]:
+        """
+        This array will not use the FlyWeight pattern that the other arrays use, since this is primarily an exploratory
+        property. If this becomes crucial, can re-organize
+        """
         if self.bkgd_corr_img_mean is not None:
-            return StandardCorrelationImages(self._u_sparse,
+            return StandardCorrelationImages.from_tensors(self._u_sparse,
                                              self.factorized_bkgd_term1 @ self.factorized_bkgd_term2,
                                              self._c,
                                              self.bkgd_corr_img_mean,
                                              self.bkgd_corr_img_normalizer,
-                                             (self._shape[1], self._shape[2]),
-                                             order=self.order)
+                                             (self._shape[1], self._shape[2]))
         else:
             return None
 
@@ -471,17 +469,9 @@ class DemixingResults(Serializer):
     def residual_correlation_images(self) -> Union[None, ResidualCorrelationImages]:
         if self.resid_corr_img_mean is not None:
             if self._residual_correlation_images is None:
-                self._residual_correlation_images = ResidualCorrelationImages(self.u,
-                                                 self.v,
-                                                 (self.factorized_bkgd_term1, self.factorized_bkgd_term2),
-                                                 self.a,
-                                                 self.c,
-                                                 self.resid_corr_img_support_values,
-                                                 self.resid_corr_img_mean,
-                                                 self.resid_corr_img_normalizer,
-                                                 (self.shape[1], self.shape[2]),
-                                                 mode=ResidCorrMode.RESIDUAL,
-                                                 order=self._order)
+                self._residual_correlation_images = ResidualCorrelationImages.from_flyweight(self,
+                                                                                             (self.shape[1], self.shape[2]),
+                                                                                             mode=ResidCorrMode.RESIDUAL)
             return self._residual_correlation_images
         else:
             return None
@@ -492,7 +482,7 @@ class DemixingResults(Serializer):
         Returns an ACArray using the tensors stored in this object
         """
         if self._ac_array is None:
-            self._ac_array = ACArray(self.fov_shape, self.a, self.c)
+            self._ac_array = ACArray.from_flyweight(self.fov_shape, self, rescale=self.rescale)
         return self._ac_array
 
     @property
@@ -501,15 +491,11 @@ class DemixingResults(Serializer):
         Returns a PMDArray using the tensors stored in this object
         """
         if self._pmd_array is None:
-            self._pmd_array = PMDArray(
+            self._pmd_array = PMDArray.from_flyweight(
                 self.shape,
-                self.u,
-                self.v,
-                self.pmd_mean_img,
-                self.pmd_var_img,
-                u_local_projector=self.pmd_u_projector,
+                self,
                 device=self.device,
-                rescale=self._rescale,
+                rescale=self.rescale,
             )
         return self._pmd_array
 
@@ -519,11 +505,17 @@ class DemixingResults(Serializer):
         Returns a PMDArray using the tensors stored in this object
         """
         if self._fluctuating_background_array is None:
-            self._fluctuating_background_array = FluctuatingBackgroundArray(self.fov_shape,
-                                          self.u,
-                                          self.factorized_bkgd_term1,
-                                          self.factorized_bkgd_term2)
+            self._fluctuating_background_array = FluctuatingBackgroundArray.from_flyweight(self.fov_shape,
+                                                                            self,
+                                                                            rescale=self.rescale)
         return self._fluctuating_background_array
+
+    @property
+    def baseline(self) -> StaticBaselineArray:
+        if self._static_baseline_array is None:
+            self._static_baseline_array = StaticBaselineArray.from_flyweight(self,
+                                                                             rescale = self.rescale)
+        return self._static_baseline_array
 
     @property
     def residual_array(self) -> ResidualArray:
@@ -531,13 +523,13 @@ class DemixingResults(Serializer):
             self._residual_array = ResidualArray(self.pmd_array,
                                                 self.ac_array,
                                                 self.fluctuating_background_array,
-                                                self.b.reshape(self.fov_shape),
+                                                self.baseline,
                                             )
         return self._residual_array
 
     @property
     def colorful_ac_array(self) -> ColorfulACArray:
         if self._colorful_ac_array is None:
-            self._colorful_ac_array = ColorfulACArray(self.fov_shape, self.a, self.c)
+            self._colorful_ac_array = ColorfulACArray.from_flyweight(self.fov_shape, self)
         return self._colorful_ac_array
 

--- a/masknmf/demixing/filters.py
+++ b/masknmf/demixing/filters.py
@@ -37,7 +37,7 @@ def spatial_filter_pmd(pmd_obj: masknmf.PMDArray,
     new_mean = torch.sparse.mm(pmd_obj.u.to(device), torch.mean(final_v.to(device), dim=1, keepdim = True))
     new_mean = new_mean.reshape(d1, d2)
 
-    final_arr = masknmf.PMDArray(pmd_obj.shape,
+    final_arr = masknmf.PMDArray.from_tensors(pmd_obj.shape,
                                  pmd_obj.u.to(device),
                                  final_v.to(device),
                                  new_mean.to(device),

--- a/masknmf/demixing/signal_demixer.py
+++ b/masknmf/demixing/signal_demixer.py
@@ -300,14 +300,13 @@ def _compute_standard_correlation_image(
         uv_meanzero_norm += num_frames * (noise_std.flatten() ** 2)[:, None]
 
     uv_meanzero_norm = torch.sqrt(uv_meanzero_norm)
-    corr_array = StandardCorrelationImages(
+    corr_array = StandardCorrelationImages.from_tensors(
         u_sparse,
         v,
         c,
         uv_mean.squeeze(),
         uv_meanzero_norm.squeeze(),
         fov_dims,
-        data_order,
     )
 
     return corr_array

--- a/masknmf/demixing/signal_demixer.py
+++ b/masknmf/demixing/signal_demixer.py
@@ -224,7 +224,8 @@ def _compute_residual_correlation_image(
     residual_array = ResidualCorrelationImages.from_tensors(
         u_sparse,
         v,
-        factorized_ring_term,
+        factorized_ring_term[0],
+        factorized_ring_term[1],
         spatial_comps,
         temporal_comps,
         resid_corr_on_support,
@@ -1928,7 +1929,7 @@ class SignalDemixer:
         self.device = device
         self.pmd_obj = pmd_array
         self.pmd_obj.to(device)
-        self.data_order = self.pmd_obj.order
+        self.data_order = "C"
         self.shape = self.pmd_obj.shape
 
         self.u_sparse = self.pmd_obj.u.float().to(self.device).coalesce()
@@ -1991,7 +1992,7 @@ class InitializingState(SignalProcessingState):
         self.shape = pmd_arr.shape[1], pmd_arr.shape[2], pmd_arr.shape[0]
         self.d1, self.d2, self.T = dimensions
         self.pmd_obj = pmd_arr
-        self.data_order = pmd_arr.order
+        self.data_order = "C"
         self.device = device
         self.pmd_obj.to(self.device)
 
@@ -2716,7 +2717,7 @@ class DemixingState(SignalProcessingState):
                 "Deletion Routine requires that a residual correlation image was calculated"
             )
 
-        support_data = self.residual_correlation_image.support_correlation_values
+        support_data = self.residual_correlation_image.resid_corr_img_support_values
         rows, columns = support_data.indices()
         values = (support_data.values() > deletion_threshold).long()
 
@@ -2770,9 +2771,9 @@ class DemixingState(SignalProcessingState):
         (
             _,
             correlation_cols,
-        ) = residual_correlation_data.support_correlation_values.indices()
+        ) = residual_correlation_data.resid_corr_img_support_values.indices()
         correlation_values = (
-            residual_correlation_data.support_correlation_values.values()
+            residual_correlation_data.resid_corr_img_support_values.values()
         )
 
         max_correlation_values.scatter_reduce_(
@@ -3033,15 +3034,14 @@ class DemixingState(SignalProcessingState):
             factorized_bkgd_term1 = self.factorized_ring_term[0],
             factorized_bkgd_term2 = self.factorized_ring_term[1],
             b = self.b.squeeze(),
-            std_corr_img_mean=self.standard_correlation_image.movie_mean,
-            std_corr_img_normalizer=self.standard_correlation_image.movie_normalizer,
-            resid_corr_img_support_values=self.residual_correlation_image.support_correlation_values,
-            resid_corr_img_mean=self.residual_correlation_image.residual_movie_mean,
-            resid_corr_img_normalizer=self.residual_correlation_image.residual_movie_normalizer,
-            bkgd_corr_img_mean=background_to_signal_correlation_image.movie_mean,
-            bkgd_corr_img_normalizer=background_to_signal_correlation_image.movie_normalizer,
+            std_corr_img_mean=self.standard_correlation_image.std_corr_img_mean,
+            std_corr_img_normalizer=self.standard_correlation_image.std_corr_img_normalizer,
+            resid_corr_img_support_values=self.residual_correlation_image.resid_corr_img_support_values,
+            resid_corr_img_mean=self.residual_correlation_image.resid_corr_img_mean,
+            resid_corr_img_normalizer=self.residual_correlation_image.resid_corr_img_normalizer,
+            bkgd_corr_img_mean=background_to_signal_correlation_image.std_corr_img_mean,
+            bkgd_corr_img_normalizer=background_to_signal_correlation_image.std_corr_img_normalizer,
             global_residual_correlation_image=torch.from_numpy(self._curr_corr_image),
-            order=self.data_order,
             device="cpu",
         )
 

--- a/masknmf/demixing/signal_demixer.py
+++ b/masknmf/demixing/signal_demixer.py
@@ -221,7 +221,7 @@ def _compute_residual_correlation_image(
         resid_corr_indices, final_values, spatial_comps.size()
     ).coalesce()
 
-    residual_array = ResidualCorrelationImages(
+    residual_array = ResidualCorrelationImages.from_tensors(
         u_sparse,
         v,
         factorized_ring_term,
@@ -232,7 +232,6 @@ def _compute_residual_correlation_image(
         robust_residual_movie_norms.squeeze(),
         fov_dims,
         mode=ResidCorrMode.DEFAULT,
-        order=data_order,
     )
     return residual_array
 

--- a/masknmf/visualization/demixing_vis.py
+++ b/masknmf/visualization/demixing_vis.py
@@ -64,7 +64,6 @@ class SingleSessionDemixingVis:
                                      "traces")
 
         self._pmd_array = self.demixing_results.pmd_array
-        self._pmd_array.rescale = False
         self._fluctuating_background_array = self.demixing_results.fluctuating_background_array
         self._residual_array = self.demixing_results.residual_array
         self._colorful_ac_array = self.demixing_results.colorful_ac_array

--- a/masknmf/visualization/plots.py
+++ b/masknmf/visualization/plots.py
@@ -8,7 +8,7 @@ import plotly.subplots as sp
 import matplotlib.pyplot as plt
 
 from masknmf.compression import PMDArray
-from masknmf.arrays import FactorizedVideo, ArrayLike, LazyFrameLoader
+from masknmf.arrays import ArrayLike, LazyFrameLoader
 from masknmf.demixing.demixing_arrays import ResidCorrMode
 
 # Custom sorting function to sort based on the numerical part after 'neuron_'
@@ -443,7 +443,7 @@ def roi_compare_pmd_raw(raw_stack: ArrayLike,
 
 
 def generate_raw_vs_resid_plot_folder(raw_stack: LazyFrameLoader,
-                                      pmd_movie: FactorizedVideo,
+                                      pmd_movie: ArrayLike,
                                       spatial_matrix: np.ndarray,
                                       folder_location: str,
                                       timeslice: Optional[slice]=None,
@@ -456,7 +456,7 @@ def generate_raw_vs_resid_plot_folder(raw_stack: LazyFrameLoader,
 
     Args:
         raw_stack (masknmf.arrays.LazyFrameLoader): Shape (num_frames, fov_dim1, fov_dim2)
-        pmd_movie (masknmf.arrays.FactorizedVideo): Shape (num_frames, fov_dim1, fov_dim2)
+        pmd_movie (masknmf.arrays.ArrayLike): Shape (num_frames, fov_dim1, fov_dim2)
         spatial_matrix (np.ndarray): Shape (fov_dim1, fov_dim2, num_neurons).
         folder_location (str): The folder path for this set of plots.
     """


### PR DESCRIPTION
Edited goals: implement the Flyweight pattern for smart re-use of tensors that should be shared across demixing results. 



Task list: 
- [x] Define the TensorFlyWeight interface and replace all instances of FactorizedVideo with this
- [x] Get each individual array serialization (if applicable), construction (with from_flyweight and from_tensors) working in the new setup. 
    - [x] PMDArray
    - [x] ACArray
    - [x] ColorfulACArray
    - [x] FluctuatingBackgroundArray
    - [x] ResidualArray (maybe this does not require any other work)
    - [x] ResidualCorrelationImages 
    - [x] StandardCorrelationImages
- [x] Update DemixingResults so that it can serves as a TensorFlyWeight for the classes
- [x] Make DemixingResults can adjust rescale for all arrays
- [x] Get rid of "ordering" in all the arrays



